### PR TITLE
Increase contact form iframe height

### DIFF
--- a/index.html
+++ b/index.html
@@ -180,7 +180,7 @@
           frameborder="0"
           marginwidth="0"
           marginheight="0"
-          style="border:0; width:100%; height:100vh; min-height:900px;"
+          style="border:0; width:100%; height:120vh; min-height:1080px;"
           allowfullscreen
           webkitallowfullscreen
           mozallowfullscreen


### PR DESCRIPTION
## Summary
- Expand contact form iframe to 120vh with 1080px minimum height for better visibility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689c903f87d4832987942451f7d3033f