### PR TITLE
Add SharePoint & Teams service card

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
 /* ======= Layout ======= */header.site-header{position:fixed;top:0;left:0;right:0;z-index:1000;background:rgba(255,255,255,.9);backdrop-filter:saturate(120%) blur(6px);border-bottom:1px solid #e5e7eb} .container{max-width:1120px;margin:0 auto;padding:0 1rem} .nav{display:flex;align-items:center;justify-content:space-between;gap:1rem;height:100px} .logo{display:flex;align-items:center;text-decoration:none;color:var(--text)} .brand-logo{height:80px;width:auto;vertical-align:middle} nav ul{list-style:none;display:flex;gap:.75rem;margin:0;padding:0} nav a{display:inline-block;padding:.5rem .75rem;border-radius:.5rem;text-decoration:none;color:var(--text)} nav a:hover, nav a:focus{background:var(--card)} main{padding-top:108px} section{padding:96px 0;scroll-margin-top:80px} section.container{padding:30px 1rem} section+section{border-top:1px solid #e5e7eb;} .muted{color:var(--muted)}
 /* Hero */ .hero{position:relative;display:grid;grid-template-columns:1fr;gap:1.25rem;align-items:center} .hero h1{font-size:clamp(1.8rem,4vw,2.6rem);line-height:1.15;margin:.25rem 0 .5rem} .hero p{font-size:1.05rem;color:var(--muted);max-width:60ch} .hero-cta{display:flex;gap:.75rem;flex-wrap:wrap;margin-top:.75rem} .hero-art{position:relative;border-radius:var(--radius);background:var(--card);box-shadow:var(--shadow);padding:1rem} .hero-art svg{width:100%;height:auto;display:block}
 /* About */ .about p{max-width:70ch}
-/* Services */ .grid{display:grid;grid-template-columns:1fr;gap:1rem} @media(min-width:720px){.grid{grid-template-columns:repeat(2,1fr)}.services .grid{grid-template-columns:repeat(5,1fr)}} .card{background:var(--card);border-radius:var(--radius);padding:1rem;box-shadow:var(--shadow)} .card h3{margin:.25rem 0 .25rem;font-size:1.05rem} .card p{margin:.25rem 0 0;color:var(--muted)} .icon{width:28px;height:28px}
+/* Services */ .grid{display:grid;grid-template-columns:1fr;gap:1rem} @media(min-width:720px){.grid{grid-template-columns:repeat(2,1fr)}.services .grid{grid-template-columns:repeat(3,1fr)}} .card{background:var(--card);border-radius:var(--radius);padding:1rem;box-shadow:var(--shadow)} .card h3{margin:.25rem 0 .25rem;font-size:1.05rem} .card p{margin:.25rem 0 0;color:var(--muted)} .icon{width:28px;height:28px}
 /* Products */ .products .product{display:grid;grid-template-columns:1fr;gap:1rem;align-items:center} @media(min-width:900px){.products .product{grid-template-columns:1.2fr .8fr}} .bullets{margin:.25rem 0 0 1.2rem} .product .imgwrap{background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem}
 /* Contact */ .contact .details{font-weight:600} .form-embed{margin-top:1rem}
 /* Footer */ footer{padding:32px 0;border-top:1px solid #e5e7eb;color:var(--muted);font-size:.95rem} .exports{display:flex;gap:.5rem;flex-wrap:wrap;margin-top:.5rem} .exports button{border:1px solid #d1d5db;background:#fff;border-radius:.5rem;padding:.4rem .6rem;cursor:pointer} .exports button:hover{background:#f3f4f6}
@@ -116,6 +116,11 @@
         <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5h10l6 7-6 7H4l6-7-6-7z" fill="#A9DFA8"/><path d="M9 12l5 7" stroke="#1f2937" stroke-width="1.5"/></svg>
         <h3>Dynamics 365 & CRM</h3>
         <p>Tailored CE customisation, Dataverse modelling, and Outlook integration to optimise CRM environments.</p>
+      </article>
+      <article class="card" aria-label="SharePoint & Teams">
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="8" cy="12" r="4" fill="#A9DFA8"/><rect x="13" y="8" width="8" height="10" rx="2" fill="#d8f3d7"/><path d="M15 12h4M15 9h4M15 15h4" stroke="#1f2937" stroke-width="1.5" fill="none"/></svg>
+        <h3>SharePoint & Teams</h3>
+        <p>SharePoint and Teams configuration and development for seamless Microsoft 365 collaboration.</p>
       </article>
       <article class="card" aria-label="Consultancy & Training">
         <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="5" width="18" height="12" rx="2" fill="#A9DFA8"/><path d="M6 18h12" stroke="#1f2937" stroke-width="1.5"/></svg>


### PR DESCRIPTION
## Summary
- add SharePoint & Teams service card
- show Services in two rows of three cards on wide screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d90d537188329a709d8621446cdf1