### PR TITLE
feat: enrich product showcase

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 /* Hero */ .hero{position:relative;display:grid;grid-template-columns:1fr;gap:1.25rem;align-items:center} .hero h1{font-size:clamp(1.8rem,4vw,2.6rem);line-height:1.15;margin:.25rem 0 .5rem} .hero p{font-size:1.05rem;color:var(--muted);max-width:60ch} .hero-cta{display:flex;gap:.75rem;flex-wrap:wrap;margin-top:.75rem} .hero-art{position:relative;border-radius:var(--radius);background:var(--card);box-shadow:var(--shadow);padding:1rem} .hero-art svg{width:100%;height:auto;display:block}
 /* About */ .about p{max-width:70ch}
 /* Services */ .grid{display:grid;grid-template-columns:1fr;gap:1rem} @media(min-width:720px){.grid{grid-template-columns:repeat(2,1fr)}.services .grid{grid-template-columns:repeat(3,1fr)}} .card{background:var(--card);border-radius:var(--radius);padding:1rem;box-shadow:var(--shadow)} .card h3{margin:.25rem 0 .25rem;font-size:1.05rem} .card p{margin:.25rem 0 0;color:var(--muted)} .icon{width:28px;height:28px}
-/* Products */ .products .product{display:grid;grid-template-columns:1fr;gap:1rem;align-items:center} @media(min-width:900px){.products .product{grid-template-columns:1.2fr .8fr}} .bullets{margin:.25rem 0 0 1.2rem} .product .imgwrap{background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem}
+/* Products */ .products .product{display:grid;grid-template-columns:1fr;gap:1rem;align-items:center;margin-block-end:6rem;margin-bottom:6rem} @media(min-width:900px){.products .product{grid-template-columns:1.2fr .8fr}} @media(max-width:639px){.products .product{margin-block-end:3rem;margin-bottom:3rem}} .bullets{margin:.25rem 0 0 1.2rem} .product .imgwrap{background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem} .placeholder{position:relative} .placeholder img{opacity:.5;display:block} .placeholder-badge{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:var(--text);color:#fff;padding:.5rem .75rem;border-radius:.5rem;font-weight:600}
 /* Contact */ .contact .details{font-weight:600} .form-embed{margin-top:1rem}
 /* Footer */ footer{padding:32px 0;border-top:1px solid #e5e7eb;color:var(--muted);font-size:.95rem} .exports{display:flex;gap:.5rem;flex-wrap:wrap;margin-top:.5rem} .exports button{border:1px solid #d1d5db;background:#fff;border-radius:.5rem;padding:.4rem .6rem;cursor:pointer} .exports button:hover{background:#f3f4f6}
 /* Motion / Reveal */ .reveal{opacity:0;transform:translateY(12px)} .reveal.revealed{opacity:1;transform:none;transition:opacity .6s ease,transform .6s ease} @media (prefers-reduced-motion: reduce){html{scroll-behavior:auto}.reveal{opacity:1;transform:none}.reveal.revealed{transition:none}}
@@ -132,22 +132,26 @@
 
   <section id="products" class="products container reveal">
     <h2>Products</h2>
-    <article class="product">
-      <div>
-        <h3>Timesheet App</h3>
+      <section class="product">
+        <div>
+          <h3>Timesheet App</h3>
         <p>A Power Platform timesheet solution for quick entry, approvals and reporting. Teams integration, role‑based access, and optional embedded Power BI.</p>
         <ul class="bullets">
           <li>Canvas app on Dataverse</li>
           <li>Multi‑stage approvals</li>
           <li>Embedded analytics & export</li>
           <li>Deployment via Deployment Pipelines or Azure DevOps </li>
-        </ul>
-      </div>
-      <div class="imgwrap">
-        <img loading="lazy" alt="Placeholder UI mock-up of a Timesheet dashboard" src='data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360"><rect width="640" height="360" fill="%23f3f6fa"/><rect x="24" y="24" width="592" height="64" rx="10" fill="%231f2937" opacity=".2"/><rect x="24" y="104" width="280" height="200" rx="12" fill="%23A9DFA8"/><rect x="320" y="104" width="296" height="20" rx="8" fill="%231f2937" opacity=".15"/><rect x="320" y="132" width="296" height="14" rx="7" fill="%231f2937" opacity=".12"/><rect x="320" y="154" width="296" height="14" rx="7" fill="%231f2937" opacity=".12"/></svg>'/>
-      </div>
-    </article>
-    <article class="product" style="margin-top:1rem">
+          </ul>
+          <p class="muted capability">Runs on Dataverse or SharePoint lists. Deployed via Power Platform Deployment Pipelines or Azure DevOps pipelines. Can be embedded in Microsoft Teams or SharePoint. Timesheets and Expenses are basic starter apps with a built-in approvals mechanism.</p>
+        </div>
+        <div class="imgwrap">
+          <div class="placeholder">
+            <img loading="lazy" alt="Placeholder UI mock-up of a Timesheet dashboard" src='data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360"><rect width="640" height="360" fill="%23f3f6fa"/><rect x="24" y="24" width="592" height="64" rx="10" fill="%231f2937" opacity=".2"/><rect x="24" y="104" width="280" height="200" rx="12" fill="%23A9DFA8"/><rect x="320" y="104" width="296" height="20" rx="8" fill="%231f2937" opacity=".15"/><rect x="320" y="132" width="296" height="14" rx="7" fill="%231f2937" opacity=".12"/><rect x="320" y="154" width="296" height="14" rx="7" fill="%231f2937" opacity=".12"/></svg>'/>
+            <span class="placeholder-badge" aria-label="Coming soon">Coming soon</span>
+          </div>
+        </div>
+      </section>
+      <section class="product" style="margin-top:1rem">
       <div>
         <h3>Expenses App</h3>
         <p>Submit, track and approve expenses with receipts and mileage. Secure by design, integrates with Dataverse and Microsoft 365.</p>
@@ -156,12 +160,16 @@
           <li>Role‑based approvals</li>
           <li>Power BI reporting</li>
           <li>Offline‑friendly patterns</li>
-        </ul>
-      </div>
-      <div class="imgwrap">
-        <img loading="lazy" alt="Placeholder UI mock-up of an Expenses dashboard" src='data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360"><rect width="640" height="360" fill="%23f3f6fa"/><rect x="24" y="24" width="592" height="64" rx="10" fill="%231f2937" opacity=".2"/><rect x="24" y="104" width="280" height="200" rx="12" fill="%23A9DFA8"/><g fill="%231f2937" opacity=".12"><rect x="320" y="104" width="296" height="20" rx="8"/><rect x="320" y="132" width="296" height="14" rx="7"/><rect x="320" y="154" width="296" height="14" rx="7"/></g></svg>'/>
-      </div>
-    </article>
+          </ul>
+          <p class="muted capability">Runs on Dataverse or SharePoint lists. Deployed via Power Platform Deployment Pipelines or Azure DevOps pipelines. Can be embedded in Microsoft Teams or SharePoint. Timesheets and Expenses are basic starter apps with a built-in approvals mechanism.</p>
+        </div>
+        <div class="imgwrap">
+          <div class="placeholder">
+            <img loading="lazy" alt="Placeholder UI mock-up of an Expenses dashboard" src='data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 360"><rect width="640" height="360" fill="%23f3f6fa"/><rect x="24" y="24" width="592" height="64" rx="10" fill="%231f2937" opacity=".2"/><rect x="24" y="104" width="280" height="200" rx="12" fill="%23A9DFA8"/><g fill="%231f2937" opacity=".12"><rect x="320" y="104" width="296" height="20" rx="8"/><rect x="320" y="132" width="296" height="14" rx="7"/><rect x="320" y="154" width="296" height="14" rx="7"/></g></svg>'/>
+            <span class="placeholder-badge" aria-label="Coming soon">Coming soon</span>
+          </div>
+        </div>
+      </section>
   </section>
 
   <!-- Contact section with embedded Microsoft Forms iframe and noscript fallback -->


### PR DESCRIPTION
## Summary
- wrap each product in its own section
- add coming-soon overlay and capability copy
- space products vertically with responsive margins

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d941ac31083298dec1337b9af20ad