### PR TITLE
Remove redundant product capability text

### DIFF
--- a/index.html
+++ b/index.html
@@ -142,7 +142,6 @@
           <li>Embedded analytics & export</li>
           <li>Deployment via Deployment Pipelines or Azure DevOps </li>
           </ul>
-          <p class="muted capability">Runs on Dataverse or SharePoint lists. Deployed via Power Platform Deployment Pipelines or Azure DevOps pipelines. Can be embedded in Microsoft Teams or SharePoint. Timesheets and Expenses are basic starter apps with a built-in approvals mechanism.</p>
         </div>
         <div class="imgwrap">
           <div class="placeholder">
@@ -161,7 +160,6 @@
           <li>Power BI reporting</li>
           <li>Offline‑friendly patterns</li>
           </ul>
-          <p class="muted capability">Runs on Dataverse or SharePoint lists. Deployed via Power Platform Deployment Pipelines or Azure DevOps pipelines. Can be embedded in Microsoft Teams or SharePoint. Timesheets and Expenses are basic starter apps with a built-in approvals mechanism.</p>
         </div>
         <div class="imgwrap">
           <div class="placeholder">


### PR DESCRIPTION
## Summary
- remove repeated capability paragraph from Timesheet and Expenses sections

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689d962ed5e883298090ad1c9cd0afb5