### PR TITLE
Set contact form iframe height to 800px

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,14 +178,14 @@
     <h2>Start a new project</h2>
     <p>Email us at <a href="mailto:info@nios-cloud.com">info@nios-cloud.com</a> or call <a href="tel:+447769249689">07769 249689</a>.</p>
 
-      <div class="form-embed" style="position:relative; overflow:hidden; height:144vh;">
+      <div class="form-embed" style="position:relative; overflow:hidden; height:800px;">
         <iframe
           title="Contact form"
           src="https://forms.office.com/Pages/ResponsePage.aspx?id=AY9GxKikMEWyBr436N-O50PfGZ_sgdtFqosStlhSWU9UQzM0S1hGR1IyMEFOUTZLNjVZNlNMNEUzTy4u&embed=true"
           frameborder="0"
           marginwidth="0"
           marginheight="0"
-          style="border:0; width:125%; height:180vh; min-height:1300px; transform:scale(0.8); transform-origin:0 0;"
+          style="border:0; width:125%; height:800px; min-height:800px; transform:scale(0.8); transform-origin:0 0;"
           allowfullscreen
           webkitallowfullscreen
           mozallowfullscreen


### PR DESCRIPTION
## Summary
- fix iframe height to 800px for the contact form

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689da02be85c83298d11855636d99efc