### PR TITLE
Increase contact form iframe height to 1200px

### DIFF
--- a/index.html
+++ b/index.html
@@ -178,14 +178,14 @@
     <h2>Start a new project</h2>
     <p>Email us at <a href="mailto:info@nios-cloud.com">info@nios-cloud.com</a> or call <a href="tel:+447769249689">07769 249689</a>.</p>
 
-      <div class="form-embed" style="position:relative; overflow:hidden; height:144vh;">
+      <div class="form-embed" style="position:relative; overflow:hidden; height:1200px;">
         <iframe
           title="Contact form"
           src="https://forms.office.com/Pages/ResponsePage.aspx?id=AY9GxKikMEWyBr436N-O50PfGZ_sgdtFqosStlhSWU9UQzM0S1hGR1IyMEFOUTZLNjVZNlNMNEUzTy4u&embed=true"
           frameborder="0"
           marginwidth="0"
           marginheight="0"
-          style="border:0; width:125%; height:180vh; min-height:1300px; transform:scale(0.8); transform-origin:0 0;"
+          style="border:0; width:125%; height:1200px; min-height:1200px; transform:scale(0.8); transform-origin:0 0;"
           allowfullscreen
           webkitallowfullscreen
           mozallowfullscreen


### PR DESCRIPTION
## Summary
- increase the iframe and container heights to 1200px in the contact form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689da02be85c83298d11855636d99efc