### PR TITLE
feat: add responsive accessible header

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,54 @@
 /* Footer */ footer{margin-top:64px;padding:48px 0 64px;border-top:1px solid #e5e7eb;color:var(--muted);font-size:.95rem;text-align:center} .social{display:flex;justify-content:center;gap:1rem;margin-top:1rem} .social a{color:inherit} .social svg{width:24px;height:24px;display:block} .exports{display:flex;gap:.5rem;flex-wrap:wrap;margin-top:1rem;justify-content:center} .exports button{border:1px solid #d1d5db;background:#fff;border-radius:.5rem;padding:.4rem .6rem;cursor:pointer} .exports button:hover{background:#f3f4f6}
 /* Motion / Reveal */ .reveal{opacity:0;transform:translateY(12px)} .reveal.revealed{opacity:1;transform:none;transition:opacity .6s ease,transform .6s ease} @media (prefers-reduced-motion: reduce){html{scroll-behavior:auto}.reveal{opacity:1;transform:none}.reveal.revealed{transition:none}}
 /* Utilities */ .pill{display:inline-block;padding:.25rem .6rem;border-radius:999px;background:var(--accent);color:#0f172a;font-weight:700;font-size:.8rem}
-/* Responsive tweaks */ @media(min-width:768px){.hero{grid-template-columns:1.1fr .9fr}} </style>
+/* Responsive tweaks */ @media(min-width:768px){.hero{grid-template-columns:1.1fr .9fr}}
+/* Header layout tweaks */ .site-header{position:fixed;top:0;left:0;right:0;z-index:1000;background:rgba(255,255,255,.9);backdrop-filter:saturate(120%) blur(6px);border-bottom:1px solid #e5e7eb}
+.nav{display:flex;align-items:center;justify-content:space-between;gap:1rem;height:72px}
+.logo{display:flex;align-items:center;text-decoration:none;color:var(--text);min-width:0}
+.brand-logo{height:40px;width:auto}
+
+/* Desktop primary nav */
+.primary-nav{display:none}
+.primary-nav ul{list-style:none;display:flex;gap:.5rem;margin:0;padding:0;flex-wrap:wrap}
+.primary-nav a{display:inline-block;padding:.5rem .75rem;border-radius:.5rem;text-decoration:none;color:var(--text)}
+.primary-nav a:hover,.primary-nav a:focus{background:var(--card)}
+
+/* Mobile toggle */
+.nav-toggle{appearance:none;border:0;background:transparent;display:inline-flex;flex-direction:column;justify-content:center;gap:4px;padding:10px;border-radius:10px}
+.nav-toggle:focus-visible{outline:3px solid var(--accent);outline-offset:2px}
+.nav-toggle-bar{display:block;width:22px;height:2px;background:var(--text);border-radius:2px}
+
+/* Mobile menu drawer */
+.mobile-menu{position:fixed;inset:72px 0 0 0;background:#fff;border-top:1px solid #e5e7eb;box-shadow:0 12px 24px rgba(0,0,0,.08);overflow:auto}
+.mobile-menu nav ul{list-style:none;margin:0;padding:12px}
+.mobile-menu li{border-bottom:1px solid #f1f5f9}
+.mobile-menu li:last-child{border-bottom:0}
+.mobile-menu a{display:block;padding:14px 16px;text-decoration:none;color:var(--text);border-radius:10px}
+.mobile-menu a:focus,.mobile-menu a:hover{background:var(--card)}
+
+/* Open state */
+body.menu-open{overflow:hidden}
+.nav-toggle[aria-expanded="true"] .nav-toggle-bar:nth-child(1){transform:translateY(6px) rotate(45deg)}
+.nav-toggle[aria-expanded="true"] .nav-toggle-bar:nth-child(2){opacity:0}
+.nav-toggle[aria-expanded="true"] .nav-toggle-bar:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
+@media (prefers-reduced-motion:no-preference){
+  .mobile-menu{transition:transform .25s ease,opacity .25s ease}
+  .mobile-menu[hidden]{display:block;opacity:0;transform:translateY(-8px);pointer-events:none}
+}
+
+/* Breakpoints: show desktop nav at ≥ 900px */
+@media (min-width:900px){
+  .nav{height:90px}
+  .brand-logo{height:64px}
+  .nav-toggle{display:none}
+  .primary-nav{display:block}
+  .mobile-menu{display:none!important}
+}
+
+/* Bump main padding to account for shorter header */
+main{padding-top:80px}
+@media (min-width:900px){main{padding-top:100px}}
+</style>
 <link rel="icon" href='data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="%23A9DFA8"/><text x="50%" y="57%" dominant-baseline="middle" text-anchor="middle" font-family="Segoe UI,Roboto,Helvetica,Arial" font-size="14" fill="%231f2937" font-weight="700">N</text></svg>'>
 </head>
 <body>
@@ -18,15 +65,37 @@
 <header class="site-header" role="banner">
   <div class="container nav" aria-label="Top navigation">
     <a class="logo" href="#home" aria-label="NIOS home">
-      <img src="images/NIOSLogoWithTextLarge.png" alt="NIOS Logo" class="brand-logo">
+      <img src="images/NIOSLogoWithTextLarge.png" alt="NIOS Logo" class="brand-logo" />
     </a>
-    <nav aria-label="Primary">
+
+    <!-- Desktop nav -->
+    <nav class="primary-nav" aria-label="Primary">
       <ul>
         <li><a href="#home">Home</a></li>
         <li><a href="#about">About</a></li>
         <li><a href="#services">Services</a></li>
         <li><a href="#products">Products</a></li>
         <li><a href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+
+    <!-- Mobile toggle button (visible on small screens) -->
+    <button class="nav-toggle" aria-controls="mobile-menu" aria-expanded="false" aria-label="Open menu">
+      <span class="nav-toggle-bar" aria-hidden="true"></span>
+      <span class="nav-toggle-bar" aria-hidden="true"></span>
+      <span class="nav-toggle-bar" aria-hidden="true"></span>
+    </button>
+  </div>
+
+  <!-- Mobile menu drawer -->
+  <div id="mobile-menu" class="mobile-menu" hidden>
+    <nav aria-label="Primary mobile">
+      <ul>
+        <li><a href="#home" data-close-menu>Home</a></li>
+        <li><a href="#about" data-close-menu>About</a></li>
+        <li><a href="#services" data-close-menu>Services</a></li>
+        <li><a href="#products" data-close-menu>Products</a></li>
+        <li><a href="#contact" data-close-menu>Contact</a></li>
       </ul>
     </nav>
   </div>
@@ -242,8 +311,62 @@
 
 <script>/* Minified-ish util JS: smooth scroll with header offset; on-scroll reveal; asset exports; year. */
 (function(){const d=document, h=d.querySelector('.site-header'); d.querySelector('#y').textContent=new Date().getFullYear();
+// === Mobile menu: toggle, focus trap, and close-on-nav ===
+const toggleBtn = document.querySelector('.nav-toggle');
+const mobileMenu = document.getElementById('mobile-menu');
+
+if (toggleBtn && mobileMenu) {
+  const focusableSel = 'a[href],button:not([disabled]),[tabindex]:not([tabindex="-1"])';
+
+  function openMenu() {
+    mobileMenu.hidden = false;
+    toggleBtn.setAttribute('aria-expanded','true');
+    document.body.classList.add('menu-open');
+    // Focus first link
+    const first = mobileMenu.querySelector(focusableSel);
+    if (first) first.focus();
+    document.addEventListener('keydown',onKeydown);
+    document.addEventListener('focusin',trapFocus);
+  }
+
+  function closeMenu() {
+    mobileMenu.hidden = true;
+    toggleBtn.setAttribute('aria-expanded','false');
+    document.body.classList.remove('menu-open');
+    toggleBtn.focus();
+    document.removeEventListener('keydown',onKeydown);
+    document.removeEventListener('focusin',trapFocus);
+  }
+
+  function onKeydown(e){
+    if (e.key === 'Escape') { closeMenu(); }
+  }
+
+  function trapFocus(e){
+    if (mobileMenu.hidden) return;
+    if (!mobileMenu.contains(e.target)) {
+      const first = mobileMenu.querySelector(focusableSel);
+      if (first) first.focus();
+    }
+  }
+
+  toggleBtn.addEventListener('click', () => {
+    const isOpen = toggleBtn.getAttribute('aria-expanded') === 'true';
+    isOpen ? closeMenu() : openMenu();
+  });
+
+  // Close when a mobile link is clicked
+  mobileMenu.querySelectorAll('[data-close-menu]').forEach(a=>{
+    a.addEventListener('click', () => closeMenu());
+  });
+
+  // Close on resize up to desktop
+  const mql = window.matchMedia('(min-width:900px)');
+  mql.addEventListener('change', e => { if (e.matches) closeMenu(); });
+}
+
  // Smooth scroll with offset
- function go(e){const a=e.target.closest('a[href^="#"]'); if(!a) return; const id=a.getAttribute('href').slice(1); if(!id) return; const safeId=(window.CSS&&window.CSS.escape)?window.CSS.escape(id):id; const el=d.getElementById(id)||d.querySelector('[id="'+safeId+'"]'); if(!el) return; e.preventDefault(); const top=el.getBoundingClientRect().top+window.scrollY-(h.offsetHeight+8); const pr=window.matchMedia('(prefers-reduced-motion: reduce)').matches; window.scrollTo({top,behavior: pr? 'auto':'smooth'});} d.querySelector('nav').addEventListener('click',go); d.querySelectorAll('a.button[href^="#"]').forEach(a=>a.addEventListener('click',go));
+  function go(e){const a=e.target.closest('a[href^="#"]'); if(!a) return; const id=a.getAttribute('href').slice(1); if(!id) return; const safeId=(window.CSS&&window.CSS.escape)?window.CSS.escape(id):id; const el=d.getElementById(id)||d.querySelector('[id="'+safeId+'"]'); if(!el) return; e.preventDefault(); const top=el.getBoundingClientRect().top+window.scrollY-(h.offsetHeight+8); const pr=window.matchMedia('(prefers-reduced-motion: reduce)').matches; window.scrollTo({top,behavior: pr? 'auto':'smooth'});} document.querySelectorAll('nav').forEach(n=>n.addEventListener('click',go)); d.querySelectorAll('a.button[href^="#"]').forEach(a=>a.addEventListener('click',go));
  // Reveal on scroll
  const prefersReduced=window.matchMedia('(prefers-reduced-motion: reduce)').matches; if(!prefersReduced && 'IntersectionObserver'in window){const io=new IntersectionObserver(es=>{es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('revealed'); io.unobserve(e.target);}})},{threshold:.12}); d.querySelectorAll('.reveal').forEach(el=>io.observe(el));}
  // Export helpers (assets/ if supported is simulated by download names)

--- a/tests/navigation.test.js
+++ b/tests/navigation.test.js
@@ -6,7 +6,7 @@ const path = require('node:path');
 // Extract the navigation function from index.html
 const html = fs.readFileSync(path.join(__dirname, '..', 'index.html'), 'utf8');
 const start = html.indexOf('function go(e)');
-const end = html.indexOf('} d.querySelector(\'nav\'', start) + 1;
+const end = html.indexOf('} document.querySelectorAll(\'nav\'', start) + 1;
 if (start === -1 || end === -1) {
   throw new Error('go function not found in index.html');
 }


### PR DESCRIPTION
## Summary
- replace static header with responsive layout featuring desktop nav and mobile drawer
- style mobile menu and toggle with responsive breakpoints
- implement JS to toggle and trap focus, updating smooth scroll bindings

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689da60eaa288329bbb9c76db4f1eb18