### PR TITLE
Improve mobile menu initialization and guards

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,8 @@
 .nav-toggle-bar{display:block;width:22px;height:2px;background:var(--text);border-radius:2px}
 
 /* Mobile menu drawer */
-.mobile-menu{position:fixed;inset:72px 0 0 0;background:#fff;border-top:1px solid #e5e7eb;box-shadow:0 12px 24px rgba(0,0,0,.08);overflow:auto}
+.mobile-menu{position:fixed;inset:72px 0 0 0;background:#fff;border-top:1px solid #e5e7eb;box-shadow:0 12px 24px rgba(0,0,0,.08);overflow:auto;display:none;opacity:0;transform:translateY(-8px);pointer-events:none}
+.mobile-menu.is-open{display:block;opacity:1;transform:none;pointer-events:auto}
 .mobile-menu nav ul{list-style:none;margin:0;padding:12px}
 .mobile-menu li{border-bottom:1px solid #f1f5f9}
 .mobile-menu li:last-child{border-bottom:0}
@@ -42,7 +43,6 @@ body.menu-open{overflow:hidden}
 .nav-toggle[aria-expanded="true"] .nav-toggle-bar:nth-child(3){transform:translateY(-6px) rotate(-45deg)}
 @media (prefers-reduced-motion:no-preference){
   .mobile-menu{transition:transform .25s ease,opacity .25s ease}
-  .mobile-menu[hidden]{display:block;opacity:0;transform:translateY(-8px);pointer-events:none}
 }
 
 /* Breakpoints: show desktop nav at ≥ 900px */
@@ -88,7 +88,7 @@ main{padding-top:80px}
   </div>
 
   <!-- Mobile menu drawer -->
-  <div id="mobile-menu" class="mobile-menu" hidden>
+    <div id="mobile-menu" class="mobile-menu">
     <nav aria-label="Primary mobile">
       <ul>
         <li><a href="#home" data-close-menu>Home</a></li>
@@ -309,69 +309,128 @@ main{padding-top:80px}
   </g>
 </svg>
 
-<script>/* Minified-ish util JS: smooth scroll with header offset; on-scroll reveal; asset exports; year. */
-(function(){const d=document, h=d.querySelector('.site-header'); d.querySelector('#y').textContent=new Date().getFullYear();
-// === Mobile menu: toggle, focus trap, and close-on-nav ===
-const toggleBtn = document.querySelector('.nav-toggle');
-const mobileMenu = document.getElementById('mobile-menu');
+<script>
+/* Minified-ish util JS: smooth scroll with header offset; on-scroll reveal; asset exports; year. */
+(function(){
+  const d = document;
+  const h = d.querySelector('.site-header');
+  const y = d.querySelector('#y');
+  if (y) y.textContent = new Date().getFullYear();
 
-if (toggleBtn && mobileMenu) {
-  const focusableSel = 'a[href],button:not([disabled]),[tabindex]:not([tabindex="-1"])';
+  document.addEventListener('DOMContentLoaded', () => {
+    const toggleBtn = d.querySelector('.nav-toggle');
+    const mobileMenu = d.getElementById('mobile-menu');
+    if (toggleBtn && mobileMenu) {
+      const focusableSel = 'a[href],button:not([disabled]),[tabindex]:not([tabindex="-1"])';
 
-  function openMenu() {
-    mobileMenu.hidden = false;
-    toggleBtn.setAttribute('aria-expanded','true');
-    document.body.classList.add('menu-open');
-    // Focus first link
-    const first = mobileMenu.querySelector(focusableSel);
-    if (first) first.focus();
-    document.addEventListener('keydown',onKeydown);
-    document.addEventListener('focusin',trapFocus);
-  }
+      function openMenu() {
+        mobileMenu.classList.add('is-open');
+        toggleBtn.setAttribute('aria-expanded', 'true');
+        document.body.classList.add('menu-open');
+        const first = mobileMenu.querySelector(focusableSel);
+        if (first) first.focus();
+        document.addEventListener('keydown', onKeydown);
+        document.addEventListener('focusin', trapFocus);
+      }
 
-  function closeMenu() {
-    mobileMenu.hidden = true;
-    toggleBtn.setAttribute('aria-expanded','false');
-    document.body.classList.remove('menu-open');
-    toggleBtn.focus();
-    document.removeEventListener('keydown',onKeydown);
-    document.removeEventListener('focusin',trapFocus);
-  }
+      function closeMenu() {
+        mobileMenu.classList.remove('is-open');
+        toggleBtn.setAttribute('aria-expanded', 'false');
+        document.body.classList.remove('menu-open');
+        toggleBtn.focus();
+        document.removeEventListener('keydown', onKeydown);
+        document.removeEventListener('focusin', trapFocus);
+      }
 
-  function onKeydown(e){
-    if (e.key === 'Escape') { closeMenu(); }
-  }
+      function onKeydown(e) {
+        if (e.key === 'Escape') closeMenu();
+      }
 
-  function trapFocus(e){
-    if (mobileMenu.hidden) return;
-    if (!mobileMenu.contains(e.target)) {
-      const first = mobileMenu.querySelector(focusableSel);
-      if (first) first.focus();
+      function trapFocus(e) {
+        if (!mobileMenu.classList.contains('is-open')) return;
+        if (!mobileMenu.contains(e.target)) {
+          const first = mobileMenu.querySelector(focusableSel);
+          if (first) first.focus();
+        }
+      }
+
+      toggleBtn.addEventListener('click', () => {
+        const isOpen = mobileMenu.classList.contains('is-open');
+        isOpen ? closeMenu() : openMenu();
+      });
+
+      mobileMenu.querySelectorAll('[data-close-menu]').forEach(a => {
+        a.addEventListener('click', () => closeMenu());
+      });
+
+      const mql = window.matchMedia('(min-width:900px)');
+      mql.addEventListener('change', e => { if (e.matches) closeMenu(); });
     }
+  });
+
+  function go(e) {
+    const a = e.target.closest('a[href^="#"]');
+    if (!a) return;
+    const id = a.getAttribute('href').slice(1);
+    if (!id) return;
+    const safeId = (window.CSS && window.CSS.escape) ? window.CSS.escape(id) : id;
+    const el = d.getElementById(id) || d.querySelector('[id="' + safeId + '"]');
+    if (!el) return;
+    e.preventDefault();
+    const top = el.getBoundingClientRect().top + window.scrollY - ((h ? h.offsetHeight : 0) + 8);
+    const pr = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    window.scrollTo({ top, behavior: pr ? 'auto' : 'smooth' });
+  } document.querySelectorAll('nav').forEach(n => n.addEventListener('click', go));
+  d.querySelectorAll('a.button[href^="#"]').forEach(a => a.addEventListener('click', go));
+
+  const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (!prefersReduced && 'IntersectionObserver' in window) {
+    const io = new IntersectionObserver(es => {
+      es.forEach(e => {
+        if (e.isIntersecting) {
+          e.target.classList.add('revealed');
+          io.unobserve(e.target);
+        }
+      });
+    }, { threshold: .12 });
+    d.querySelectorAll('.reveal').forEach(el => io.observe(el));
   }
 
-  toggleBtn.addEventListener('click', () => {
-    const isOpen = toggleBtn.getAttribute('aria-expanded') === 'true';
-    isOpen ? closeMenu() : openMenu();
+  function dl(blob, name) {
+    const u = URL.createObjectURL(blob), a = d.createElement('a');
+    a.href = u; a.download = name; d.body.appendChild(a);
+    a.click(); a.remove(); setTimeout(() => URL.revokeObjectURL(u), 1500);
+  }
+
+  function svgBlob(id) {
+    const src = d.getElementById(id);
+    if (!src) return new Blob();
+    const n = src.cloneNode(true);
+    const t = '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(n);
+    return new Blob([t], { type: 'image/svg+xml' });
+  }
+
+  const saveSvg = d.getElementById('saveSvg');
+  if (saveSvg) saveSvg.addEventListener('click', () => dl(svgBlob('logo-light-src'), 'assets/nios-logo.svg'));
+  const saveSvgDark = d.getElementById('saveSvgDark');
+  if (saveSvgDark) saveSvgDark.addEventListener('click', () => dl(svgBlob('logo-dark-src'), 'assets/nios-logo-dark.svg'));
+  const savePng = d.getElementById('savePng');
+  if (savePng) savePng.addEventListener('click', () => {
+    const src = d.getElementById('logo-light-src');
+    if (!src) return;
+    const s = src.cloneNode(true);
+    const c = d.createElement('canvas');
+    c.width = 32; c.height = 32;
+    const ctx = c.getContext('2d');
+    const img = new Image();
+    const data = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(new XMLSerializer().serializeToString(s));
+    img.onload = function() {
+      ctx.drawImage(img, 0, 0, 32, 32);
+      c.toBlob(b => dl(b, 'assets/nios-favicon-32.png'));
+    };
+    img.src = data;
   });
-
-  // Close when a mobile link is clicked
-  mobileMenu.querySelectorAll('[data-close-menu]').forEach(a=>{
-    a.addEventListener('click', () => closeMenu());
-  });
-
-  // Close on resize up to desktop
-  const mql = window.matchMedia('(min-width:900px)');
-  mql.addEventListener('change', e => { if (e.matches) closeMenu(); });
-}
-
- // Smooth scroll with offset
-  function go(e){const a=e.target.closest('a[href^="#"]'); if(!a) return; const id=a.getAttribute('href').slice(1); if(!id) return; const safeId=(window.CSS&&window.CSS.escape)?window.CSS.escape(id):id; const el=d.getElementById(id)||d.querySelector('[id="'+safeId+'"]'); if(!el) return; e.preventDefault(); const top=el.getBoundingClientRect().top+window.scrollY-(h.offsetHeight+8); const pr=window.matchMedia('(prefers-reduced-motion: reduce)').matches; window.scrollTo({top,behavior: pr? 'auto':'smooth'});} document.querySelectorAll('nav').forEach(n=>n.addEventListener('click',go)); d.querySelectorAll('a.button[href^="#"]').forEach(a=>a.addEventListener('click',go));
- // Reveal on scroll
- const prefersReduced=window.matchMedia('(prefers-reduced-motion: reduce)').matches; if(!prefersReduced && 'IntersectionObserver'in window){const io=new IntersectionObserver(es=>{es.forEach(e=>{if(e.isIntersecting){e.target.classList.add('revealed'); io.unobserve(e.target);}})},{threshold:.12}); d.querySelectorAll('.reveal').forEach(el=>io.observe(el));}
- // Export helpers (assets/ if supported is simulated by download names)
- function dl(blob, name){const u=URL.createObjectURL(blob), a=d.createElement('a'); a.href=u; a.download=name; d.body.appendChild(a); a.click(); a.remove(); setTimeout(()=>URL.revokeObjectURL(u),1500);} function svgBlob(id){const n=d.getElementById(id).cloneNode(true); const t='<?xml version="1.0" encoding="UTF-8"?>\n'+new XMLSerializer().serializeToString(n); return new Blob([t],{type:'image/svg+xml'});} d.getElementById('saveSvg').addEventListener('click',()=>dl(svgBlob('logo-light-src'),'assets/nios-logo.svg')); d.getElementById('saveSvgDark').addEventListener('click',()=>dl(svgBlob('logo-dark-src'),'assets/nios-logo-dark.svg'));
- // PNG favicon 32
- d.getElementById('savePng').addEventListener('click',()=>{const s=d.getElementById('logo-light-src').cloneNode(true); const c=d.createElement('canvas'); c.width=32; c.height=32; const ctx=c.getContext('2d'); const img=new Image(); const data='data:image/svg+xml;charset=utf-8,'+encodeURIComponent(new XMLSerializer().serializeToString(s)); img.onload=function(){ctx.drawImage(img,0,0,32,32); c.toBlob(b=>dl(b,'assets/nios-favicon-32.png'));}; img.src=data;});})();</script>
+})();
+</script>
 </body></html>
 


### PR DESCRIPTION
## Summary
- Wrap mobile menu script in DOMContentLoaded and toggle `.is-open` class with `aria-expanded`
- Guard DOM lookups to avoid runtime errors
- Show mobile navigation only when `.is-open` class is set

## Testing
- `npm test`
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_689da998ab308329912312fa5cbf1b05