### PR TITLE
Overhaul mobile menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,10 +28,17 @@
         width:48px;height:48px;cursor:pointer;
       }
       .mobile-nav{
-        position:fixed;top:72px;right:1rem;
-        background:var(--card);box-shadow:var(--shadow);
-        border-radius:.5rem;padding:.5rem;z-index:1001;
+        position:fixed;inset:0;
+        background:rgba(0,0,0,.5);
+        display:flex;flex-direction:column;
+        align-items:center;justify-content:center;gap:2rem;
+        z-index:1001;
+        opacity:0;visibility:hidden;pointer-events:none;
+        transition:opacity .3s ease;
       }
+      .mobile-nav.open{opacity:1;visibility:visible;pointer-events:auto}
+      .mobile-nav ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:1.5rem;align-items:center}
+      .mobile-nav a{color:#fff;font-size:1.5rem;text-decoration:none}
       @media(min-width:900px){
         .menu-toggle{display:none}
         .mobile-nav{display:none}
@@ -76,9 +83,8 @@ main{padding-top:80px}
     </button>
 
     <!-- Mobile menu -->
-    <nav id="mobileNav" class="mobile-nav" hidden aria-label="Mobile">
+    <nav id="mobileNav" class="mobile-nav" aria-label="Mobile" aria-hidden="true">
       <ul>
-        <li><a href="#home">Home</a></li>
         <li><a href="#about">About</a></li>
         <li><a href="#services">Services</a></li>
         <li><a href="#products">Products</a></li>
@@ -373,14 +379,15 @@ main{padding-top:80px}
   const mobileNav = document.getElementById('mobileNav');
   if (menuBtn && mobileNav){
     menuBtn.addEventListener('click', () => {
-      const expanded = menuBtn.getAttribute('aria-expanded') === 'true';
-      menuBtn.setAttribute('aria-expanded', String(!expanded));
-      mobileNav.hidden = expanded;
+      const open = mobileNav.classList.toggle('open');
+      menuBtn.setAttribute('aria-expanded', String(open));
+      mobileNav.setAttribute('aria-hidden', String(!open));
     });
     mobileNav.addEventListener('click', e => {
       if (e.target.closest('a')){
+        mobileNav.classList.remove('open');
         menuBtn.setAttribute('aria-expanded', 'false');
-        mobileNav.hidden = true;
+        mobileNav.setAttribute('aria-hidden', 'true');
       }
     });
   }

--- a/tests/mobile-nav.test.js
+++ b/tests/mobile-nav.test.js
@@ -22,8 +22,19 @@ function setup() {
     setAttribute: (name, value) => { menuBtn.attrs[name] = value; }
   };
   const mobileNav = {
-    hidden: true,
-    addEventListener: (type, fn) => { if (type === 'click') navClick = fn; }
+    attrs: { 'aria-hidden': 'true' },
+    cls: new Set(),
+    addEventListener: (type, fn) => { if (type === 'click') navClick = fn; },
+    classList: {
+      toggle: name => {
+        if (mobileNav.cls.has(name)) { mobileNav.cls.delete(name); return false; }
+        mobileNav.cls.add(name); return true;
+      },
+      remove: name => { mobileNav.cls.delete(name); },
+      contains: name => mobileNav.cls.has(name)
+    },
+    getAttribute: name => mobileNav.attrs[name],
+    setAttribute: (name, value) => { mobileNav.attrs[name] = value; }
   };
   global.document = {
     getElementById: id => {
@@ -40,15 +51,17 @@ function setup() {
   };
 }
 
-test('button toggles hidden and aria-expanded', () => {
+test('button toggles class and aria attributes', () => {
   const env = setup();
   eval(navSrc);
   env.clickToggle();
   assert.equal(env.menuBtn.getAttribute('aria-expanded'), 'true');
-  assert.equal(env.mobileNav.hidden, false);
+  assert.equal(env.mobileNav.classList.contains('open'), true);
+  assert.equal(env.mobileNav.getAttribute('aria-hidden'), 'false');
   env.clickToggle();
   assert.equal(env.menuBtn.getAttribute('aria-expanded'), 'false');
-  assert.equal(env.mobileNav.hidden, true);
+  assert.equal(env.mobileNav.classList.contains('open'), false);
+  assert.equal(env.mobileNav.getAttribute('aria-hidden'), 'true');
 });
 
 test('link click closes menu', () => {
@@ -57,5 +70,6 @@ test('link click closes menu', () => {
   env.clickToggle();
   env.clickLink();
   assert.equal(env.menuBtn.getAttribute('aria-expanded'), 'false');
-  assert.equal(env.mobileNav.hidden, true);
+  assert.equal(env.mobileNav.classList.contains('open'), false);
+  assert.equal(env.mobileNav.getAttribute('aria-hidden'), 'true');
 });


### PR DESCRIPTION
## Summary
- Replace small dropdown with full-screen mobile nav overlay featuring fade-in/out transitions
- List About, Services, Products, and Contact links vertically on a semi-transparent backdrop
- Update tests to cover new `open` class and aria attributes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dc904c0148329b185ccb08bb9b0f4