### PR TITLE
feat: add fade overlay to mobile menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,9 +34,12 @@
         align-items:center;justify-content:center;gap:2rem;
         z-index:1001;
         opacity:0;visibility:hidden;pointer-events:none;
-        transition:opacity .3s ease;
+        transition:opacity .3s ease,visibility 0s linear .3s;
       }
-      .mobile-nav.open{opacity:1;visibility:visible;pointer-events:auto}
+      .mobile-nav.open{
+        opacity:1;visibility:visible;pointer-events:auto;
+        transition:opacity .3s ease,visibility 0s;
+      }
       .mobile-nav ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:1.5rem;align-items:center}
       .mobile-nav a{color:#fff;font-size:1.5rem;text-decoration:none}
       @media(min-width:900px){


### PR DESCRIPTION
## Summary
- ensure mobile menu overlay fades smoothly and stays visible while fading
- transition visibility alongside opacity for a polished closing effect

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dcce6a31c832984a33744b3bac140