### PR TITLE
Improve mobile menu interactions and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,7 @@
       }
       .mobile-nav ul{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:1.5rem;align-items:center}
       .mobile-nav a{color:#fff;font-size:1.5rem;text-decoration:none}
+      .mobile-nav a:hover{color:#1f2937}
       @media(min-width:900px){
         .menu-toggle{display:none}
         .mobile-nav{display:none}
@@ -393,6 +394,15 @@ main{padding-top:80px}
       toggle.setAttribute('aria-expanded', String(isOpen));
       menu.toggleAttribute('hidden', !isOpen);
       document.body.style.overflow = isOpen ? 'hidden' : '';
+      toggle.textContent = isOpen ? '✕' : '☰';
+    });
+    menu.addEventListener('click', e => {
+      if (!e.target.closest('a')) return;
+      menu.classList.toggle('open');
+      toggle.setAttribute('aria-expanded', 'false');
+      menu.toggleAttribute('hidden', true);
+      document.body.style.overflow = '';
+      toggle.textContent = '☰';
     });
   }
 })();

--- a/tests/mobile-nav.test.js
+++ b/tests/mobile-nav.test.js
@@ -13,9 +13,10 @@ if (start === -1 || end === -1) {
 const navSrc = html.slice(start, end);
 
 function setup() {
-  let btnClick;
+  let btnClick, menuClick;
   const toggle = {
     attrs: { 'aria-expanded': 'false' },
+    textContent: '☰',
     addEventListener: (type, fn) => { if (type === 'click') btnClick = fn; },
     getAttribute: name => toggle.attrs[name],
     setAttribute: (name, value) => { toggle.attrs[name] = value; }
@@ -37,7 +38,8 @@ function setup() {
       }
       if (force) { menu.attrs[name] = ''; return true; }
       delete menu.attrs[name]; return false;
-    }
+    },
+    addEventListener: (type, fn) => { if (type === 'click') menuClick = fn; }
   };
   const body = { style: {} };
   global.document = {
@@ -49,7 +51,8 @@ function setup() {
     toggle,
     menu,
     body,
-    clickToggle: () => btnClick && btnClick()
+    clickToggle: () => btnClick && btnClick(),
+    clickMenuLink: () => menuClick && menuClick({ target: { closest: () => ({}) } })
   };
 }
 
@@ -61,10 +64,24 @@ test('button toggles menu visibility and body scroll', () => {
   assert.equal(env.menu.classList.contains('open'), true);
   assert.equal('hidden' in env.menu.attrs, false);
   assert.equal(env.body.style.overflow, 'hidden');
+  assert.equal(env.toggle.textContent, '✕');
   env.clickToggle();
   assert.equal(env.toggle.getAttribute('aria-expanded'), 'false');
   assert.equal(env.menu.classList.contains('open'), false);
   assert.equal('hidden' in env.menu.attrs, true);
   assert.equal(env.body.style.overflow, '');
+  assert.equal(env.toggle.textContent, '☰');
+});
+
+test('clicking a menu link closes the menu', () => {
+  const env = setup();
+  eval(navSrc);
+  env.clickToggle();
+  env.clickMenuLink();
+  assert.equal(env.toggle.getAttribute('aria-expanded'), 'false');
+  assert.equal(env.menu.classList.contains('open'), false);
+  assert.equal('hidden' in env.menu.attrs, true);
+  assert.equal(env.body.style.overflow, '');
+  assert.equal(env.toggle.textContent, '☰');
 });
 


### PR DESCRIPTION
## Summary
- Change mobile menu link hover color to dark blue
- Toggle hamburger into close icon and close menu after link selection
- Expand tests for mobile navigation toggle behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689dd31fd19c8329b7f24457f7513d01