### PR TITLE
Add home and exit options to mobile menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,10 +93,12 @@ main{padding-top:80px}
 </header>
 <nav id="mobileNav" class="mobile-nav" aria-label="Mobile" hidden>
   <ul>
+    <li><a href="#home">Home</a></li>
     <li><a href="#about">About</a></li>
     <li><a href="#services">Services</a></li>
     <li><a href="#products">Products</a></li>
     <li><a href="#contact">Contact</a></li>
+    <li><a href="#" data-exit>Exit</a></li>
   </ul>
 </nav>
 <main id="home" tabindex="-1">
@@ -394,15 +396,15 @@ main{padding-top:80px}
       toggle.setAttribute('aria-expanded', String(isOpen));
       menu.toggleAttribute('hidden', !isOpen);
       document.body.style.overflow = isOpen ? 'hidden' : '';
-      toggle.textContent = isOpen ? '✕' : '☰';
     });
     menu.addEventListener('click', e => {
-      if (!e.target.closest('a')) return;
+      const link = e.target.closest('a');
+      if (!link) return;
+      if (link.hasAttribute('data-exit')) e.preventDefault();
       menu.classList.toggle('open');
       toggle.setAttribute('aria-expanded', 'false');
       menu.toggleAttribute('hidden', true);
       document.body.style.overflow = '';
-      toggle.textContent = '☰';
     });
   }
 })();

--- a/tests/mobile-nav.test.js
+++ b/tests/mobile-nav.test.js
@@ -52,7 +52,15 @@ function setup() {
     menu,
     body,
     clickToggle: () => btnClick && btnClick(),
-    clickMenuLink: () => menuClick && menuClick({ target: { closest: () => ({}) } })
+    clickMenuLink: () => menuClick && menuClick({ target: { closest: () => ({ hasAttribute: () => false }) } }),
+    clickExitLink: () => {
+      let prevented = false;
+      menuClick && menuClick({
+        target: { closest: () => ({ hasAttribute: attr => attr === 'data-exit' }) },
+        preventDefault: () => { prevented = true; }
+      });
+      return { prevented };
+    }
   };
 }
 
@@ -64,7 +72,7 @@ test('button toggles menu visibility and body scroll', () => {
   assert.equal(env.menu.classList.contains('open'), true);
   assert.equal('hidden' in env.menu.attrs, false);
   assert.equal(env.body.style.overflow, 'hidden');
-  assert.equal(env.toggle.textContent, '✕');
+  assert.equal(env.toggle.textContent, '☰');
   env.clickToggle();
   assert.equal(env.toggle.getAttribute('aria-expanded'), 'false');
   assert.equal(env.menu.classList.contains('open'), false);
@@ -83,5 +91,18 @@ test('clicking a menu link closes the menu', () => {
   assert.equal('hidden' in env.menu.attrs, true);
   assert.equal(env.body.style.overflow, '');
   assert.equal(env.toggle.textContent, '☰');
+});
+
+test('clicking the exit link closes the menu without navigation', () => {
+  const env = setup();
+  eval(navSrc);
+  env.clickToggle();
+  const res = env.clickExitLink();
+  assert.equal(env.toggle.getAttribute('aria-expanded'), 'false');
+  assert.equal(env.menu.classList.contains('open'), false);
+  assert.equal('hidden' in env.menu.attrs, true);
+  assert.equal(env.body.style.overflow, '');
+  assert.equal(env.toggle.textContent, '☰');
+  assert.equal(res.prevented, true);
 });
 


### PR DESCRIPTION
## Summary
- Add Home and Exit links to mobile navigation list
- Wire Exit link to close the mobile menu and remove non-functional X toggle
- Update mobile nav tests for new behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dde9faba883299021c390d4cc4274