### PR TITLE
Add full-screen hero carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html><html lang="en-GB"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>NIOS — Microsoft Power Platform Consulting</title><meta name="description" content="NIOS — We design, build and support Microsoft Power Platform solutions across Power Apps, Dynamics 365, Power Automate and Power BI."><!-- Optional CSP note: if you add a Content-Security-Policy later, allow: frame-src https://forms.office.com; -->
-<style>/* ======= Base / Tokens ======= */:root{--accent:#A9DFA8;--bg:#ffffff;--text:#1f2937;--muted:#6b7280;--card:#f8fafc;--radius:18px;--shadow:0 6px 24px rgba(0,0,0,.08),0 2px 8px rgba(0,0,0,.06)}*{box-sizing:border-box}html{scroll-behavior:smooth}html:focus-within{scroll-behavior:smooth}body{margin:0;background:var(--bg) url('images/NIOSback.png') no-repeat center center fixed;background-size:cover;color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji";line-height:1.5}img{max-width:100%;height:auto}svg{shape-rendering:geometricPrecision;text-rendering:optimizeLegibility}a{color:inherit}a.button{display:inline-block;padding:.85rem 1.15rem;border-radius:999px;background:var(--text);color:#fff;text-decoration:none;font-weight:600;box-shadow:var(--shadow)}a.button.alt{background:transparent;color:var(--text);border:2px solid var(--text);box-shadow:none}a.button:hover{opacity:.9}
+<style>/* ======= Base / Tokens ======= */:root{--accent:#A9DFA8;--bg:#ffffff;--text:#1f2937;--muted:#6b7280;--card:#f8fafc;--radius:18px;--shadow:0 6px 24px rgba(0,0,0,.08),0 2px 8px rgba(0,0,0,.06);--header-height:72px}*{box-sizing:border-box}html{scroll-behavior:smooth}html:focus-within{scroll-behavior:smooth}body{margin:0;background:var(--bg) url('images/NIOSback.png') no-repeat center center fixed;background-size:cover;color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,Ubuntu,Cantarell,Noto Sans,Helvetica,Arial,"Apple Color Emoji","Segoe UI Emoji";line-height:1.5}img{max-width:100%;height:auto}svg{shape-rendering:geometricPrecision;text-rendering:optimizeLegibility}a{color:inherit}a.button{display:inline-block;padding:.85rem 1.15rem;border-radius:999px;background:var(--text);color:#fff;text-decoration:none;font-weight:600;box-shadow:var(--shadow)}a.button.alt{background:transparent;color:var(--text);border:2px solid var(--text);box-shadow:none}a.button:hover{opacity:.9}
 /* ======= Accessibility ======= */.skip-link{position:absolute;left:-999px;top:auto;width:1px;height:1px;overflow:hidden}.skip-link:focus{left:1rem;top:1rem;width:auto;height:auto;z-index:9999;background:#000;color:#fff;padding:.5rem .75rem;border-radius:.5rem} :focus{outline:3px solid var(--accent);outline-offset:2px} :focus:not(:focus-visible){outline:none}
 /* ======= Layout ======= */header.site-header{position:fixed;top:0;left:0;right:0;z-index:1000;background:rgba(255,255,255,.9);backdrop-filter:saturate(120%) blur(6px);border-bottom:1px solid #e5e7eb} .container{max-width:1120px;margin:0 auto;padding:0 1rem} .nav{display:flex;align-items:center;justify-content:space-between;gap:1rem;height:100px} .logo{display:flex;align-items:center;text-decoration:none;color:var(--text)} .brand-logo{height:80px;width:auto;vertical-align:middle} nav ul{list-style:none;display:flex;gap:.75rem;margin:0;padding:0} nav a{display:inline-block;padding:.5rem .75rem;border-radius:.5rem;text-decoration:none;color:var(--text)} nav a:hover, nav a:focus{background:var(--card)} main{padding-top:108px} section{padding:96px 0;scroll-margin-top:80px} section.container{padding:30px 1rem} section+section{border-top:1px solid #e5e7eb;} .muted{color:var(--muted)}
-/* Hero */ .hero{position:relative;display:grid;grid-template-columns:1fr;gap:1.25rem;align-items:center} .hero h1{font-size:clamp(1.8rem,4vw,2.6rem);line-height:1.15;margin:.25rem 0 .5rem} .hero p{font-size:1.05rem;color:var(--muted);max-width:60ch} .hero-cta{display:flex;gap:.75rem;flex-wrap:wrap;margin-top:.75rem} .hero-art{position:relative;border-radius:var(--radius);background:var(--card);box-shadow:var(--shadow);padding:1rem} .hero-art svg{width:100%;height:auto;display:block}
+/* Hero */ .hero{position:relative;display:grid;grid-template-columns:1fr;gap:1.25rem;align-items:center;min-height:calc(100vh - var(--header-height));padding:0} .hero h1{font-size:clamp(1.8rem,4vw,2.6rem);line-height:1.15;margin:.25rem 0 .5rem} .hero p{font-size:1.05rem;color:var(--muted);max-width:60ch} .hero-cta{display:flex;gap:.75rem;flex-wrap:wrap;margin-top:.75rem} .hero-carousel{position:relative;border-radius:var(--radius);background:var(--card);box-shadow:var(--shadow);overflow:hidden} .hero-carousel .slides{display:flex;transition:transform .5s ease} .hero-carousel .slide{min-width:100%;flex-shrink:0} .hero-carousel img{width:100%;height:auto;display:block} .hero-carousel button{position:absolute;top:50%;transform:translateY(-50%);background:rgba(31,41,55,.6);color:#fff;border:0;border-radius:50%;width:32px;height:32px;cursor:pointer} .hero-carousel .prev{left:8px} .hero-carousel .next{right:8px} .hero-carousel .dots{position:absolute;bottom:8px;left:50%;transform:translateX(-50%);display:flex;gap:4px} .hero-carousel .dots button{width:10px;height:10px;border:0;border-radius:50%;background:rgba(255,255,255,.6);cursor:pointer} .hero-carousel .dots button.active{background:var(--accent)}
 /* About */ .about p{max-width:70ch}
 /* Services */ .grid{display:grid;grid-template-columns:1fr;gap:1rem} .services .grid{gap:1.25rem} @media(min-width:720px){.grid{grid-template-columns:repeat(2,1fr)}.services .grid{grid-template-columns:repeat(3,1fr)}} .card{background:var(--card);border-radius:var(--radius);padding:1rem;box-shadow:var(--shadow)} .card h3{margin:.25rem 0 .25rem;font-size:1.05rem} .card p{margin:.25rem 0 0;color:var(--muted)} .icon{width:28px;height:28px} .services .card{display:flex;flex-direction:column;justify-content:space-between;min-height:320px} .service-img{margin-top:1rem;border-radius:var(--radius);width:100%;aspect-ratio:16/9;object-fit:cover}
 /* Products */ .products .product{display:grid;grid-template-columns:1fr;gap:1rem;align-items:center;padding:1.5rem 0;margin-block-end:1.5rem;margin-bottom:1.5rem;border-top:none} @media(min-width:900px){.products .product{grid-template-columns:1.2fr .8fr}} @media(max-width:639px){.products .product{padding:1rem 0;margin-block-end:1rem;margin-bottom:1rem}} .bullets{margin:.25rem 0 0 1.2rem} .product .imgwrap{background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem} .placeholder{position:relative} .placeholder img{opacity:.5;display:block} .placeholder-badge{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:var(--text);color:#fff;padding:.5rem .75rem;border-radius:.5rem;font-weight:600}
@@ -11,6 +11,7 @@
 /* Motion / Reveal */ .reveal{opacity:0;transform:translateY(12px)} .reveal.revealed{opacity:1;transform:none;transition:opacity .6s ease,transform .6s ease} @media (prefers-reduced-motion: reduce){html{scroll-behavior:auto}.reveal{opacity:1;transform:none}.reveal.revealed{transition:none}}
 /* Utilities */ .pill{display:inline-block;padding:.25rem .6rem;border-radius:999px;background:var(--accent);color:#0f172a;font-weight:700;font-size:.8rem}
 /* Responsive tweaks */ @media(min-width:768px){.hero{grid-template-columns:1.1fr .9fr}}
+@media(min-width:900px){:root{--header-height:90px}}
 /* Header layout tweaks */ .site-header{position:fixed;top:0;left:0;right:0;z-index:1000;background:rgba(255,255,255,.9);backdrop-filter:saturate(120%) blur(6px);border-bottom:1px solid #e5e7eb}
 .nav{display:flex;align-items:center;justify-content:space-between;gap:1rem;height:72px}
 .logo{display:flex;align-items:center;text-decoration:none;color:var(--text);min-width:0}
@@ -59,9 +60,8 @@
   .primary-nav{display:block}
 }
 
-/* Bump main padding to account for shorter header */
-main{padding-top:80px}
-@media (min-width:900px){main{padding-top:100px}}
+/* Bump main padding to account for fixed header */
+main{padding-top:var(--header-height)}
 /* Mobile background */
 @media (max-width:899px){body{background-image:url('images/NIOSmobilebackground.jpg');}}
 </style>
@@ -114,48 +114,19 @@ main{padding-top:80px}
         <a class="button alt" href="#products">See our work</a>
       </div>
     </div>
-    <div class="hero-art" aria-hidden="true">
-      <!-- Abstract Microsoft-ecosystem illustration (SVG) -->
-      <svg viewBox="0 0 720 420" xmlns="http://www.w3.org/2000/svg" role="img" aria-label=""
-        preserveAspectRatio="xMidYMid meet">
-        <defs>
-          <filter id="s" x="-20%" y="-20%" width="140%" height="140%"><feDropShadow dx="0" dy="2" stdDeviation="6" flood-color="#000" flood-opacity=".08"/></filter>
-        </defs>
-        <rect width="100%" height="100%" rx="16" fill="#fff"/>
-        <g filter="url(#s)">
-          <rect x="40" y="40" width="220" height="140" rx="14" fill="#f3f6fa"/>
-          <rect x="70" y="70" width="160" height="16" rx="8" fill="#1f2937" opacity=".2"/>
-          <rect x="70" y="100" width="120" height="12" rx="6" fill="#1f2937" opacity=".12"/>
-          <rect x="70" y="120" width="180" height="12" rx="6" fill="#1f2937" opacity=".12"/>
-        </g>
-        <g filter="url(#s)">
-          <rect x="280" y="60" width="380" height="260" rx="16" fill="#f3f6fa"/>
-          <g transform="translate(310,90)">
-            <rect width="320" height="24" rx="12" fill="#1f2937" opacity=".2"/>
-            <rect y="40" width="140" height="140" rx="12" fill="#A9DFA8"/>
-            <rect x="160" y="40" width="150" height="16" rx="8" fill="#1f2937" opacity=".15"/>
-            <rect x="160" y="66" width="180" height="12" rx="6" fill="#1f2937" opacity=".12"/>
-            <rect x="160" y="86" width="180" height="12" rx="6" fill="#1f2937" opacity=".12"/>
-            <rect x="0" y="190" width="320" height="8" rx="4" fill="#1f2937" opacity=".08"/>
-          </g>
-        </g>
-        <g filter="url(#s)">
-          <rect x="60" y="220" width="240" height="140" rx="14" fill="#f3f6fa"/>
-          <!-- Sparkline bars -->
-          <g transform="translate(90,250)" fill="#1f2937" opacity=".18">
-            <rect width="14" height="60" rx="4"/>
-            <rect x="26" width="14" height="42" rx="4"/>
-            <rect x="52" width="14" height="70" rx="4"/>
-            <rect x="78" width="14" height="32" rx="4"/>
-            <rect x="104" width="14" height="56" rx="4"/>
-            <rect x="130" width="14" height="44" rx="4"/>
-          </g>
-        </g>
-        <!-- Accent nodes -->
-        <circle cx="660" cy="80" r="8" fill="#A9DFA8"/>
-        <circle cx="620" cy="340" r="6" fill="#A9DFA8"/>
-        <circle cx="40" cy="200" r="6" fill="#A9DFA8"/>
-      </svg>
+    <div class="hero-carousel" aria-label="Featured highlights">
+      <div class="slides">
+        <div class="slide"><img src="images/service-placeholder.svg" alt="Power Platform app development" /></div>
+        <div class="slide"><img src="images/service-placeholder.svg" alt="Automated workflow solutions" /></div>
+        <div class="slide"><img src="images/service-placeholder.svg" alt="Business intelligence dashboards" /></div>
+      </div>
+      <button class="prev" aria-label="Previous slide">&#10094;</button>
+      <button class="next" aria-label="Next slide">&#10095;</button>
+      <div class="dots">
+        <button aria-label="Go to slide 1" class="active"></button>
+        <button aria-label="Go to slide 2"></button>
+        <button aria-label="Go to slide 3"></button>
+      </div>
     </div>
   </section>
 
@@ -341,6 +312,27 @@ main{padding-top:80px}
       toggle.setAttribute('aria-expanded', 'false');
       menu.toggleAttribute('hidden', true);
       document.body.style.overflow = '';
+    });
+  }
+  const carousel = document.querySelector('.hero-carousel');
+  if (carousel){
+    const slides = carousel.querySelector('.slides');
+    const dots = carousel.querySelectorAll('.dots button');
+    let idx = 0, startX = null;
+    function show(n){
+      idx = (n + dots.length) % dots.length;
+      slides.style.transform = `translateX(-${idx*100}%)`;
+      dots.forEach((b,i)=>b.classList.toggle('active', i === idx));
+    }
+    carousel.querySelector('.prev').addEventListener('click', ()=>show(idx-1));
+    carousel.querySelector('.next').addEventListener('click', ()=>show(idx+1));
+    dots.forEach((b,i)=>b.addEventListener('click', ()=>show(i)));
+    slides.addEventListener('touchstart', e=>startX=e.touches[0].clientX);
+    slides.addEventListener('touchend', e=>{
+      if(startX===null) return;
+      const dx = e.changedTouches[0].clientX - startX;
+      if(Math.abs(dx)>50) show(idx + (dx<0 ? 1 : -1));
+      startX=null;
     });
   }
 })();


### PR DESCRIPTION
## Summary
- make hero section span the initial screen using a header-height variable
- replace placeholder art with a responsive 3-slide carousel
- enable swipe and button controls for the carousel

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a080dfe0648329be6997da2dd5b709