### PR TITLE
Increase brand logo size without altering header height

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
 /* Header layout tweaks */ .site-header{position:fixed;top:0;left:0;right:0;z-index:1000;background:rgba(255,255,255,.9);backdrop-filter:saturate(120%) blur(6px);border-bottom:1px solid #e5e7eb}
 .nav{display:flex;align-items:center;justify-content:space-between;gap:1rem;height:72px}
 .logo{display:flex;align-items:center;text-decoration:none;color:var(--text);min-width:0}
-.brand-logo{height:40px;width:auto}
+.brand-logo{height:60px;width:auto}
 
 /* Desktop primary nav */
 .primary-nav{display:none}
@@ -56,7 +56,7 @@
       /* Breakpoints: show desktop nav at ≥ 900px */
       @media (min-width:900px){
         .nav{height:90px}
-        .brand-logo{height:64px}
+        .brand-logo{height:80px}
   .primary-nav{display:block}
 }
 


### PR DESCRIPTION
## Summary
- enlarge `.brand-logo` to 60px on mobile and 80px on desktop
- retain existing nav heights (72px mobile, 90px desktop)

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a082e84a708329b149d8de5baae0a7