### PR TITLE
style: adjust hero layout for desktop

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 /* Utilities */ .pill{display:inline-block;padding:.25rem .6rem;border-radius:999px;background:var(--accent);color:#0f172a;font-weight:700;font-size:.8rem}
 /* Responsive tweaks */ @media(min-width:768px){.hero{grid-template-columns:1fr}}
 @media(min-width:900px){:root{--header-height:90px}}
-@media(min-width:900px){.carousel{width:70%;justify-self:center}}
+@media(min-width:900px){.hero{grid-template-columns:1fr 1fr}.carousel{max-width:450px;width:100%;justify-self:end}}
 /* Header layout tweaks */ .site-header{position:fixed;top:0;left:0;right:0;z-index:1000;background:rgba(255,255,255,.9);backdrop-filter:saturate(120%) blur(6px);border-bottom:1px solid #e5e7eb}
 .nav{display:flex;align-items:center;justify-content:space-between;gap:1rem;height:72px}
 .logo{display:flex;align-items:center;text-decoration:none;color:var(--text);min-width:0}


### PR DESCRIPTION
## Summary
- adjust desktop hero layout to two-column grid
- constrain carousel width and align to right on desktop

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a097589d6883299d5b1fd9d1ae7a4f