### PR TITLE
Link all Contact buttons to modal and remove contact section

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 /* Services */ .grid{display:grid;grid-template-columns:1fr;gap:1rem} .services .grid{gap:1.25rem} @media(min-width:720px){.grid{grid-template-columns:repeat(2,1fr)}.services .grid{grid-template-columns:repeat(3,1fr)}} .card{background:var(--card);border-radius:var(--radius);padding:1rem;box-shadow:var(--shadow)} .card h3{margin:.25rem 0 .25rem;font-size:1.05rem} .card p{margin:.25rem 0 0;color:var(--muted)} .icon{width:28px;height:28px} .services .card{display:flex;flex-direction:column;justify-content:space-between;min-height:320px} .service-img{margin-top:1rem;border-radius:var(--radius);width:100%;aspect-ratio:16/9;object-fit:cover}
 /* Products */ .products .product{display:grid;grid-template-columns:1fr;gap:1rem;align-items:center;padding:1.5rem 0;margin-block-end:1.5rem;margin-bottom:1.5rem;border-top:none} @media(min-width:900px){.products .product{grid-template-columns:1.2fr .8fr}} @media(max-width:639px){.products .product{padding:1rem 0;margin-block-end:1rem;margin-bottom:1rem}} .bullets{margin:.25rem 0 0 1.2rem} .product .imgwrap{background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem} .placeholder{position:relative} .placeholder img{opacity:.5;display:block} .placeholder-badge{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:var(--text);color:#fff;padding:.5rem .75rem;border-radius:.5rem;font-weight:600}
 /* CTA */ .cta{text-align:center} .cta .button{margin-top:.5rem}
-/* Contact */ .contact .details{font-weight:600} .contact .open-form-btn{margin-top:1rem} .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:1200} .modal{position:relative;background:#fff;border-radius:var(--radius);box-shadow:var(--shadow);max-width:800px;width:90%;padding:1rem;max-height:90vh;display:flex;flex-direction:column} .modal iframe{width:100%;height:80vh;border:0} .modal-close{position:absolute;top:.5rem;right:.5rem;background:none;border:0;font-size:1.5rem;cursor:pointer}
+  /* Contact */ .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:1200} .modal{position:relative;background:#fff;border-radius:var(--radius);box-shadow:var(--shadow);max-width:800px;width:90%;padding:1rem;max-height:90vh;display:flex;flex-direction:column} .modal iframe{width:100%;height:80vh;border:0} .modal-close{position:absolute;top:.5rem;right:.5rem;background:none;border:0;font-size:1.5rem;cursor:pointer}
 /* Footer */ footer{margin-top:64px;padding:48px 0 64px;border-top:1px solid #e5e7eb;color:var(--muted);font-size:.95rem;text-align:center} .footer-nav{display:flex;flex-wrap:wrap;justify-content:center;gap:.75rem;margin-bottom:1rem} .footer-nav a{color:inherit;padding:.25rem .5rem;border-radius:.5rem;text-decoration:none} .footer-nav a:hover,.footer-nav a:focus{background:var(--card);color:var(--text)}
 /* Motion / Reveal */ .reveal{opacity:0;transform:translateY(12px)} .reveal.revealed{opacity:1;transform:none;transition:opacity .6s ease,transform .6s ease} @media (prefers-reduced-motion: reduce){html{scroll-behavior:auto}.reveal{opacity:1;transform:none}.reveal.revealed{transition:none}}
 /* Utilities */ .pill{display:inline-block;padding:.25rem .6rem;border-radius:999px;background:var(--accent);color:#0f172a;font-weight:700;font-size:.8rem}
@@ -235,15 +235,7 @@ main{padding-top:var(--header-height)}
     <a class="button" href="#contact">Contact us</a>
   </section>
 
-  <!-- Contact section with button to open Microsoft Forms modal and noscript fallback -->
-  <section id="contact" class="container">
-    <h2>Start a new project</h2>
-    <p>Email us at <a href="mailto:info@nios-cloud.com">info@nios-cloud.com</a> or call <a href="tel:+447769249689">07769 249689</a>.</p>
-    <button id="openContactForm" class="button open-form-btn">Open Contact Form</button>
-    <noscript>
-      <p>Form not loading? <a href="https://forms.office.com/Pages/ResponsePage.aspx?id=AY9GxKikMEWyBr436N-O50PfGZ_sgdtFqosStlhSWU9UQzM0S1hGR1IyMEFOUTZLNjVZNlNMNEUzTy4u" target="_blank" rel="noopener">Open the form in a new tab</a>.</p>
-    </noscript>
-  </section>
+
 </main>
 
   <footer class="container">
@@ -337,54 +329,56 @@ main{padding-top:var(--header-height)}
     },5000);
   }
 
-  const contactBtn = document.getElementById('openContactForm');
-  if (contactBtn){
-    contactBtn.addEventListener('click', ()=>{
-      const overlay = document.createElement('div');
-      overlay.className = 'modal-overlay';
-      const modal = document.createElement('div');
-      modal.className = 'modal';
-      modal.setAttribute('role','dialog');
-      modal.setAttribute('aria-modal','true');
-      modal.setAttribute('aria-label','Contact form');
-      const closeBtn = document.createElement('button');
-      closeBtn.className = 'modal-close';
-      closeBtn.type = 'button';
-      closeBtn.textContent = '\u00D7 Close';
-      const iframe = document.createElement('iframe');
-      iframe.src = 'https://forms.office.com/Pages/ResponsePage.aspx?id=AY9GxKikMEWyBr436N-O50PfGZ_sgdtFqosStlhSWU9UQzM0S1hGR1IyMEFOUTZLNjVZNlNMNEUzTy4u&embed=true';
-      iframe.title = 'Contact form';
-      iframe.setAttribute('allowfullscreen','');
-      iframe.setAttribute('referrerpolicy','strict-origin-when-cross-origin');
-      const startTrap = document.createElement('span');
-      startTrap.tabIndex = 0;
-      startTrap.setAttribute('aria-hidden','true');
-      startTrap.style.cssText = 'position:absolute;width:0;height:0;overflow:hidden';
-      const endTrap = document.createElement('span');
-      endTrap.tabIndex = 0;
-      endTrap.setAttribute('aria-hidden','true');
-      endTrap.style.cssText = 'position:absolute;width:0;height:0;overflow:hidden';
-      startTrap.addEventListener('focus', () => iframe.focus());
-      endTrap.addEventListener('focus', () => closeBtn.focus());
-      modal.append(startTrap, closeBtn, iframe, endTrap);
-      overlay.appendChild(modal);
-      document.body.appendChild(overlay);
-      document.body.style.overflow = 'hidden';
-      const prev = document.activeElement;
-      closeBtn.focus();
-      function close(){
-        overlay.remove();
-        document.body.style.overflow = '';
-        document.removeEventListener('keydown', onKey);
-        if(prev) prev.focus();
-      }
-      function onKey(e){
-        if(e.key === 'Escape') close();
-      }
-      closeBtn.addEventListener('click', close);
-      overlay.addEventListener('click', e => { if(e.target === overlay) close(); });
-      document.addEventListener('keydown', onKey);
-    });
+  const contactLinks = document.querySelectorAll ? document.querySelectorAll('a[href="#contact"]') : [];
+  if (contactLinks.length){
+    contactLinks.forEach(link => link.addEventListener('click', openContactForm));
+  }
+  function openContactForm(e){
+    e.preventDefault();
+    const overlay = document.createElement('div');
+    overlay.className = 'modal-overlay';
+    const modal = document.createElement('div');
+    modal.className = 'modal';
+    modal.setAttribute('role','dialog');
+    modal.setAttribute('aria-modal','true');
+    modal.setAttribute('aria-label','Contact form');
+    const closeBtn = document.createElement('button');
+    closeBtn.className = 'modal-close';
+    closeBtn.type = 'button';
+    closeBtn.textContent = '\u00D7 Close';
+    const iframe = document.createElement('iframe');
+    iframe.src = 'https://forms.office.com/Pages/ResponsePage.aspx?id=AY9GxKikMEWyBr436N-O50PfGZ_sgdtFqosStlhSWU9UQzM0S1hGR1IyMEFOUTZLNjVZNlNMNEUzTy4u&embed=true';
+    iframe.title = 'Contact form';
+    iframe.setAttribute('allowfullscreen','');
+    iframe.setAttribute('referrerpolicy','strict-origin-when-cross-origin');
+    const startTrap = document.createElement('span');
+    startTrap.tabIndex = 0;
+    startTrap.setAttribute('aria-hidden','true');
+    startTrap.style.cssText = 'position:absolute;width:0;height:0;overflow:hidden';
+    const endTrap = document.createElement('span');
+    endTrap.tabIndex = 0;
+    endTrap.setAttribute('aria-hidden','true');
+    endTrap.style.cssText = 'position:absolute;width:0;height:0;overflow:hidden';
+    startTrap.addEventListener('focus', () => iframe.focus());
+    endTrap.addEventListener('focus', () => closeBtn.focus());
+    modal.append(startTrap, closeBtn, iframe, endTrap);
+    overlay.appendChild(modal);
+    document.body.appendChild(overlay);
+    document.body.style.overflow = 'hidden';
+    const prev = document.activeElement;
+    closeBtn.focus();
+    function close(){
+      overlay.remove();
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', onKey);
+      if(prev) prev.focus();
+    }
+    function onKey(e){
+      if(e.key === 'Escape') close();
+    }
+    closeBtn.addEventListener('click', close);
+    overlay.addEventListener('click', e => { if(e.target === overlay) close(); });
+    document.addEventListener('keydown', onKey);
   }
 })();
 </script>


### PR DESCRIPTION
## Summary
- Remove direct contact section, keeping CTA intact
- Trigger modal form from any "Contact" link, including nav and floating button

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a1057303fc83299aff95998c1add2a