### PR TITLE
Ensure contact form modal fills mobile screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,6 +68,10 @@
 main{padding-top:var(--header-height)}
 /* Mobile background */
 @media (max-width:899px){body{background-image:url('images/NIOSmobilebackground.jpg');}}
+@media (max-width:600px){
+ .modal{width:100%;height:100vh;max-width:none;max-height:none;border-radius:0;padding:0;}
+ .modal iframe{width:100%;height:100%;transform:none;}
+}
 </style>
 <link rel="icon" href='data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="%23A9DFA8"/><text x="50%" y="57%" dominant-baseline="middle" text-anchor="middle" font-family="Segoe UI,Roboto,Helvetica,Arial" font-size="14" fill="%231f2937" font-weight="700">N</text></svg>'>
 </head>


### PR DESCRIPTION
## Summary
- expand CSS to make contact modal occupy full viewport on screens 600px wide or less
- verify contact form creation logic still inserts modal and iframe without size or scale tweaks

## Testing
- `npm test`
- `node - <<'NODE' ... NODE`
- `npm install playwright` *(fails: E403 Forbidden)*
- `npm install puppeteer` *(fails: E403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a119890b908329811980033333c4b9