### PR TITLE
Add contact form exit button

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
 /* Services */ .grid{display:grid;grid-template-columns:1fr;gap:1rem} .services .grid{gap:1.25rem} @media(min-width:720px){.grid{grid-template-columns:repeat(2,1fr)}.services .grid{grid-template-columns:repeat(3,1fr)}} .card{background:var(--card);border-radius:var(--radius);padding:1rem;box-shadow:var(--shadow)} .card h3{margin:.25rem 0 .25rem;font-size:1.05rem} .card p{margin:.25rem 0 0;color:var(--muted)} .icon{width:28px;height:28px} .services .card{display:flex;flex-direction:column;justify-content:space-between;min-height:320px} .service-img{margin-top:1rem;border-radius:var(--radius);width:100%;aspect-ratio:16/9;object-fit:cover}
 /* Products */ .products .product{display:grid;grid-template-columns:1fr;gap:1rem;align-items:center;padding:1.5rem 0;margin-block-end:1.5rem;margin-bottom:1.5rem;border-top:none} @media(min-width:900px){.products .product{grid-template-columns:1.2fr .8fr}} @media(max-width:639px){.products .product{padding:1rem 0;margin-block-end:1rem;margin-bottom:1rem}} .bullets{margin:.25rem 0 0 1.2rem} .product .imgwrap{background:var(--card);border-radius:var(--radius);box-shadow:var(--shadow);padding:1rem} .placeholder{position:relative} .placeholder img{opacity:.5;display:block} .placeholder-badge{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);background:var(--text);color:#fff;padding:.5rem .75rem;border-radius:.5rem;font-weight:600}
 /* CTA */ .cta{text-align:center} .cta .button{margin-top:.5rem}
-/* Contact */ .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:1200} .modal{position:relative;background:#fff;border-radius:var(--radius);box-shadow:var(--shadow);max-width:1200px;width:95%;height:95vh;max-height:95vh;padding:1rem 1rem 0;display:flex;flex-direction:column;overflow:auto} .modal iframe{flex:1;width:100%;height:100%;border:0;transform:none}.modal-info{font-weight:600;margin-bottom:1rem} .modal-close{position:absolute;top:.5rem;right:.5rem;background:none;border:0;font-size:1.5rem;cursor:pointer}
+/* Contact */ .modal-overlay{position:fixed;inset:0;background:rgba(0,0,0,.6);display:flex;align-items:center;justify-content:center;z-index:1200} .modal{position:relative;background:#fff;border-radius:var(--radius);box-shadow:var(--shadow);max-width:1200px;width:95%;height:95vh;max-height:95vh;padding:1rem 1rem 0;display:flex;flex-direction:column;overflow:auto} .modal iframe{flex:1;width:100%;height:100%;border:0;transform:none}.modal-info{font-weight:600;margin-bottom:1rem} .modal-close{position:absolute;top:.5rem;right:.5rem;background:none;border:0;font-size:1.5rem;cursor:pointer} .modal-exit{margin:1rem auto;padding:.75rem 1rem;border:0;border-radius:999px;background:var(--text);color:#fff;font-weight:600;cursor:pointer}
 /* Footer */ footer{margin-top:64px;padding:48px 0 64px;border-top:1px solid #e5e7eb;color:var(--muted);font-size:.95rem;text-align:center} .footer-nav{display:flex;flex-wrap:wrap;justify-content:center;gap:.75rem;margin-bottom:1rem} .footer-nav a{color:inherit;padding:.25rem .5rem;border-radius:.5rem;text-decoration:none} .footer-nav a:hover,.footer-nav a:focus{background:var(--card);color:var(--text)}
 /* Motion / Reveal */ .reveal{opacity:0;transform:translateY(12px)} .reveal.revealed{opacity:1;transform:none;transition:opacity .6s ease,transform .6s ease} @media (prefers-reduced-motion: reduce){html{scroll-behavior:auto}.reveal{opacity:1;transform:none}.reveal.revealed{transition:none}}
 /* Utilities */ .pill{display:inline-block;padding:.25rem .6rem;border-radius:999px;background:var(--accent);color:#0f172a;font-weight:700;font-size:.8rem}
@@ -344,12 +344,16 @@ main{padding-top:var(--header-height)}
     modal.setAttribute('role','dialog');
     modal.setAttribute('aria-modal','true');
     modal.setAttribute('aria-label','Contact form');
-    const closeBtn = document.createElement('button');
-    closeBtn.className = 'modal-close';
-    closeBtn.type = 'button';
-    closeBtn.textContent = '\u00D7 Close';
-    const info = document.createElement('p');
-    info.className = 'modal-info';
+      const closeBtn = document.createElement('button');
+      closeBtn.className = 'modal-close';
+      closeBtn.type = 'button';
+      closeBtn.textContent = '\u00D7 Close';
+      const exitBtn = document.createElement('button');
+      exitBtn.className = 'modal-exit';
+      exitBtn.type = 'button';
+      exitBtn.textContent = 'Exit';
+      const info = document.createElement('p');
+      info.className = 'modal-info';
     info.innerHTML = 'Email us at <a href="mailto:info@nios-cloud.com">info@nios-cloud.com</a> or call <a href="tel:+447769249689">07769 249689</a>.';
     const iframe = document.createElement('iframe');
     iframe.src = 'https://forms.office.com/Pages/ResponsePage.aspx?id=AY9GxKikMEWyBr436N-O50PfGZ_sgdtFqosStlhSWU9UQzM0S1hGR1IyMEFOUTZLNjVZNlNMNEUzTy4u&embed=true';
@@ -366,7 +370,7 @@ main{padding-top:var(--header-height)}
     endTrap.style.cssText = 'position:absolute;width:0;height:0;overflow:hidden';
     startTrap.addEventListener('focus', () => iframe.focus());
     endTrap.addEventListener('focus', () => closeBtn.focus());
-    modal.append(startTrap, closeBtn, info, iframe, endTrap);
+      modal.append(startTrap, closeBtn, info, iframe, exitBtn, endTrap);
     overlay.appendChild(modal);
     document.body.appendChild(overlay);
     document.body.style.overflow = 'hidden';
@@ -381,8 +385,9 @@ main{padding-top:var(--header-height)}
     function onKey(e){
       if(e.key === 'Escape') close();
     }
-    closeBtn.addEventListener('click', close);
-    overlay.addEventListener('click', e => { if(e.target === overlay) close(); });
+      closeBtn.addEventListener('click', close);
+      exitBtn.addEventListener('click', close);
+      overlay.addEventListener('click', e => { if(e.target === overlay) close(); });
     document.addEventListener('keydown', onKey);
   }
 })();


### PR DESCRIPTION
## Summary
- Add dedicated Exit button to contact form modal for mobile users
- Style new modal-exit button
- Ensure exit button closes modal alongside existing close control

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a11e58504c83298107cd5197c13b53