### PR TITLE
Move mobile contact exit button to top right

### DIFF
--- a/index.html
+++ b/index.html
@@ -71,6 +71,8 @@ main{padding-top:var(--header-height)}
 @media (max-width:600px){
  .modal{width:100%;height:100vh;max-width:none;max-height:none;border-radius:0;padding:0;}
  .modal iframe{width:100%;height:100%;transform:none;}
+ .modal-close{display:none;}
+ .modal-exit{position:absolute;top:.5rem;right:.5rem;margin:0;}
 }
 </style>
 <link rel="icon" href='data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="%23A9DFA8"/><text x="50%" y="57%" dominant-baseline="middle" text-anchor="middle" font-family="Segoe UI,Roboto,Helvetica,Arial" font-size="14" fill="%231f2937" font-weight="700">N</text></svg>'>


### PR DESCRIPTION
## Summary
- Reposition mobile contact modal exit button to the top-right corner and hide duplicate close control on small screens

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a12c9c15f083299297bd5e3726394d