### PR TITLE
feat: update theme color variables

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,37 +153,37 @@ main{padding-top:var(--header-height)}
     <h2>Services</h2>
     <div class="grid">
       <article class="card" aria-label="Power Platform Apps">
-        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="3" width="8" height="8" rx="2" fill="#A9D9A7"/><rect x="13" y="3" width="8" height="8" rx="2" fill="#E4F3E3"/><rect x="3" y="13" width="8" height="8" rx="2" fill="#EBF6EA"/><rect x="13" y="13" width="8" height="8" rx="2" fill="#A9D9A7"/></svg>
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="3" width="8" height="8" rx="2" fill="var(--accent)"/><rect x="13" y="3" width="8" height="8" rx="2" fill="var(--card)"/><rect x="3" y="13" width="8" height="8" rx="2" fill="var(--card)"/><rect x="13" y="13" width="8" height="8" rx="2" fill="var(--accent)"/></svg>
         <h3>Power Platform Apps</h3>
         <p>Bespoke canvas and model-driven apps powered by Dataverse, with secure role management and streamlined ALM pipelines.</p>
         <img src="images/service-placeholder.svg" alt="" class="service-img" loading="lazy" />
       </article>
       <article class="card" aria-label="Process Automation">
-        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="6" cy="6" r="3" fill="#A9D9A7"/><circle cx="18" cy="6" r="3" fill="#A9D9A7"/><circle cx="12" cy="18" r="3" fill="#A9D9A7"/><path d="M9 6h6M6 9l4 7M18 9l-4 7" stroke="#253140" stroke-width="1.5" fill="none"/></svg>
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="6" cy="6" r="3" fill="var(--accent)"/><circle cx="18" cy="6" r="3" fill="var(--accent)"/><circle cx="12" cy="18" r="3" fill="var(--accent)"/><path d="M9 6h6M6 9l4 7M18 9l-4 7" stroke="var(--text)" stroke-width="1.5" fill="none"/></svg>
         <h3>Process Automation</h3>
         <p>End-to-end automation with Power Automate, Logic Apps, and Azure Functions, integrating seamlessly via REST and Graph APIs.</p>
         <img src="images/service-placeholder.svg" alt="" class="service-img" loading="lazy" />
       </article>
       <article class="card" aria-label="Data & Analytics">
-        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="10" width="4" height="10" rx="1" fill="#A9D9A7"/><rect x="10" y="4" width="4" height="16" rx="1" fill="#A9D9A7"/><rect x="17" y="8" width="4" height="12" rx="1" fill="#A9D9A7"/></svg>
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="10" width="4" height="10" rx="1" fill="var(--accent)"/><rect x="10" y="4" width="4" height="16" rx="1" fill="var(--accent)"/><rect x="17" y="8" width="4" height="12" rx="1" fill="var(--accent)"/></svg>
         <h3>Data & Analytics</h3>
         <p>Insight-driven Power BI solutions with DAX, Power Query, SQL, and Microsoft Fabric for clear, actionable reporting.</p>
         <img src="images/service-placeholder.svg" alt="" class="service-img" loading="lazy" />
       </article>
       <article class="card" aria-label="Dynamics 365 & CRM">
-        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5h10l6 7-6 7H4l6-7-6-7z" fill="#A9D9A7"/><path d="M9 12l5 7" stroke="#253140" stroke-width="1.5"/></svg>
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 5h10l6 7-6 7H4l6-7-6-7z" fill="var(--accent)"/><path d="M9 12l5 7" stroke="var(--text)" stroke-width="1.5"/></svg>
         <h3>Dynamics 365 & CRM</h3>
         <p>Tailored CE customisation, Dataverse modelling, and Outlook integration to optimise CRM environments.</p>
         <img src="images/service-placeholder.svg" alt="" class="service-img" loading="lazy" />
       </article>
       <article class="card" aria-label="SharePoint & Teams">
-        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="8" cy="12" r="4" fill="#A9D9A7"/><rect x="13" y="8" width="8" height="10" rx="2" fill="#E4F3E3"/><path d="M15 12h4M15 9h4M15 15h4" stroke="#253140" stroke-width="1.5" fill="none"/></svg>
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="8" cy="12" r="4" fill="var(--accent)"/><rect x="13" y="8" width="8" height="10" rx="2" fill="var(--card)"/><path d="M15 12h4M15 9h4M15 15h4" stroke="var(--text)" stroke-width="1.5" fill="none"/></svg>
         <h3>SharePoint & Teams</h3>
         <p>SharePoint and Teams configuration and development for seamless Microsoft 365 collaboration.</p>
         <img src="images/service-placeholder.svg" alt="" class="service-img" loading="lazy" />
       </article>
       <article class="card" aria-label="Consultancy & Training">
-        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="5" width="18" height="12" rx="2" fill="#A9D9A7"/><path d="M6 18h12" stroke="#253140" stroke-width="1.5"/></svg>
+        <svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><rect x="3" y="5" width="18" height="12" rx="2" fill="var(--accent)"/><path d="M6 18h12" stroke="var(--text)" stroke-width="1.5"/></svg>
         <h3>Consultancy & Training</h3>
         <p>Expert workshops, requirement analysis, architecture design, and user training with ongoing support.</p>
         <img src="images/service-placeholder.svg" alt="" class="service-img" loading="lazy" />


### PR DESCRIPTION
## Summary
- refresh theme colors with darker text and soft green accents
- ensure WCAG AA contrast between text and backgrounds
- sync inline assets to the new palette

## Testing
- `npm test`
- Calculated color contrast ratios via Python script


------
https://chatgpt.com/codex/tasks/task_e_68a372e5e9148329bdc2192dc7958376