### PR TITLE
Add hero quick contact CTA

### DIFF
--- a/partials/hero.html
+++ b/partials/hero.html
@@ -5,6 +5,12 @@
     <p>From concept to delivery, we design secure, scalable solutions using Power Platform, Azure, Microsoft 365, SharePoint and Teams — enabling rapid deployment, customisability and smarter workflows.</p>
     <div class="hero-cta">
       <a class="button alt" href="#products">See our work</a>
+      <a class="button contact-button" href="#contact">
+        <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
+          <path d="M6.62 10.79a15.05 15.05 0 006.59 6.59l1.84-1.84a1 1 0 011.02-.24 11.36 11.36 0 003.56.57 1 1 0 011 1v3.58a1 1 0 01-1 1A17.62 17.62 0 012 6a1 1 0 011-1h3.59a1 1 0 011 1 11.36 11.36 0 00.57 3.56 1 1 0 01-.24 1.02z" />
+        </svg>
+        <span>Quick contact</span>
+      </a>
     </div>
   </div>
   <div class="carousel" aria-label="Featured highlights">

--- a/styles/main.css
+++ b/styles/main.css
@@ -57,6 +57,21 @@ a.button {
   box-shadow: var(--shadow);
 }
 
+a.button.contact-button {
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  background: var(--accent);
+  color: var(--text);
+  border: 2px solid transparent;
+}
+
+a.button.contact-button svg {
+  width: 1.15rem;
+  height: 1.15rem;
+  fill: currentColor;
+}
+
 a.button.alt {
   background: transparent;
   color: var(--text);


### PR DESCRIPTION
## Summary
- add a quick contact button next to the primary hero call-to-action
- style the new contact button with accent color and inline icon support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d7e2c573a083299ebd6c42a4eb1151