### PR TITLE
Refine hero CTA button styling

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -47,40 +47,61 @@ a {
 }
 
 a.button {
-  display: inline-block;
-  padding: .85rem 1.15rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: .65rem;
+  padding: .9rem 1.4rem;
   border-radius: 999px;
   background: var(--text);
   color: var(--bg);
   text-decoration: none;
   font-weight: 600;
-  box-shadow: var(--shadow);
-}
-
-a.button.contact-button {
-  display: inline-flex;
-  align-items: center;
-  gap: .5rem;
-  background: var(--accent);
-  color: var(--text);
+  font-size: 1rem;
+  line-height: 1;
   border: 2px solid transparent;
+  box-shadow: var(--shadow);
+  transition: transform .2s ease, box-shadow .2s ease, background-color .2s ease, color .2s ease;
 }
 
-a.button.contact-button svg {
+a.button svg {
   width: 1.15rem;
   height: 1.15rem;
   fill: currentColor;
 }
 
+a.button.contact-button {
+  background: var(--accent);
+  color: var(--text);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, .09);
+}
+
 a.button.alt {
   background: transparent;
   color: var(--text);
-  border: 2px solid var(--text);
+  border-color: var(--text);
+  border-color: color-mix(in srgb, var(--text) 85%, transparent);
   box-shadow: none;
 }
 
-a.button:hover {
-  opacity: .9;
+a.button:hover,
+a.button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(0, 0, 0, .12);
+}
+
+a.button.alt:hover,
+a.button.alt:focus-visible {
+  background: rgba(var(--text-rgb), .08);
+  background: color-mix(in srgb, var(--text) 8%, transparent);
+  color: var(--text);
+  box-shadow: none;
+}
+
+a.button.contact-button:hover,
+a.button.contact-button:focus-visible {
+  background: var(--accent);
+  background: color-mix(in srgb, var(--accent) 90%, white);
 }
 
 /* ======= Accessibility ======= */


### PR DESCRIPTION
## Summary
- restyled the hero call-to-action buttons with consistent inline-flex layout, padding, and transitions for improved polish
- refreshed the quick contact accent button with a softer shadow and safer color-mix fallbacks for hover states

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7e882c374832980d6449c751eb7ee