### PR TITLE
Fix mobile overflow caused by figure margins

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -30,6 +30,10 @@ svg {
   display: block;
 }
 
+figure {
+  margin: 0;
+}
+
 a {
   color: inherit;
 }


### PR DESCRIPTION
## Summary
- reset default figure margins so media cards fit within the mobile viewport

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d9250841208329948df5ee97df2c11