### PR TITLE
Reset site to barebones template

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,12 +3,11 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>NIOS — Microsoft Power Platform Consulting</title>
-    <meta name="description" content="NIOS — We design, build and support Microsoft Power Platform solutions across Power Apps, Dynamics 365, Power Automate and Power BI." />
-    <!-- Optional CSP note: if you add a Content-Security-Policy later, allow: frame-src https://forms.office.com; -->
+    <title>NIOS Website Template</title>
+    <meta name="description" content="Base template for the NIOS website." />
     <link rel="stylesheet" href="styles/tokens.css" />
     <link rel="stylesheet" href="styles/main.css" />
-    <link rel="icon" href='data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="%23A9D9A7"/><text x="50%" y="57%" dominant-baseline="middle" text-anchor="middle" font-family="Segoe UI,Roboto,Helvetica,Arial" font-size="14" fill="%23253140" font-weight="700">N</text></svg>' />
+    <link rel="icon" href='data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="%23A9D9A7"/></svg>' />
     <script src="scripts/main.js" type="module" defer></script>
   </head>
   <body>
@@ -23,7 +22,7 @@
     </main>
     <div data-include="partials/footer.html"></div>
     <noscript>
-      <p style="text-align:center;padding:1rem 0 3rem;">Enable JavaScript to view the full NIOS experience.</p>
+      <p style="text-align:center;padding:1rem 0 3rem;">Enable JavaScript to view the full experience.</p>
     </noscript>
   </body>
 </html>

--- a/partials/about.html
+++ b/partials/about.html
@@ -1,30 +1,7 @@
 <section id="about" class="section reveal">
-  <div class="shell about__layout">
-    <div class="about__intro">
-      <header class="section__header">
-        <span class="section__eyebrow">About NIOS</span>
-        <h2>Focused Microsoft expertise that keeps your platform moving</h2>
-      </header>
-      <p>We design, implement and optimise Microsoft business applications so teams can deliver measurable change without waiting on long development cycles.</p>
-      <ul class="about__list">
-        <li>Power Platform apps, automation and analytics shaped by real adoption goals.</li>
-        <li>Dynamics 365 Customer Engagement tuned for relationship-driven teams.</li>
-        <li>SharePoint and Microsoft Teams experiences that anchor collaboration.</li>
-      </ul>
-    </div>
-    <div class="about__pillars" role="list">
-      <article class="about-card" role="listitem">
-        <h3>Consult &amp; roadmap</h3>
-        <p>Assess current-state processes, governance and licensing to chart the right Microsoft-first plan.</p>
-      </article>
-      <article class="about-card" role="listitem">
-        <h3>Design &amp; delivery</h3>
-        <p>Blend low-code accelerators with custom development to launch solutions rapidly and securely.</p>
-      </article>
-      <article class="about-card" role="listitem">
-        <h3>Adopt &amp; evolve</h3>
-        <p>Enable your teams with training, support and iterative enhancements that keep value compounding.</p>
-      </article>
-    </div>
+  <div class="shell">
+    <header class="section__header">
+      <h2>About</h2>
+    </header>
   </div>
 </section>

--- a/partials/contact.html
+++ b/partials/contact.html
@@ -1,26 +1,7 @@
 <section id="contact" class="section reveal" aria-labelledby="contact-title">
   <div class="shell">
-    <div class="contact">
-      <header class="section__header">
-        <span class="section__eyebrow" id="contact-title">Contact</span>
-        <h2>Let’s shape your next Power Platform initiative</h2>
-        <p class="section__lede">Tell us about your Microsoft environment, the processes to transform and any timelines you’re working toward. We’ll reply within one business day with suggested next steps.</p>
-      </header>
-      <div class="contact__grid">
-        <article class="contact-card" aria-label="Ways to reach NIOS">
-          <h3>Talk with us</h3>
-          <p>We collaborate on scope, delivery roadmaps and enablement plans tailored to your organisation.</p>
-          <ul class="contact-list">
-            <li><a href="mailto:info@nios-cloud.com">info@nios-cloud.com</a></li>
-            <li><a href="https://www.linkedin.com/company/nios-cloud" target="_blank" rel="noopener">Connect on LinkedIn</a></li>
-          </ul>
-        </article>
-        <div class="contact-placeholder" role="group" aria-labelledby="contact-form-placeholder">
-          <strong id="contact-form-placeholder">Project intake form coming soon</strong>
-          <p>This space will host our secure intake form covering project goals, stakeholders and delivery preferences.</p>
-          <p>Until then, send us an email and we’ll prepare a focused agenda for our first conversation.</p>
-        </div>
-      </div>
-    </div>
+    <header class="section__header">
+      <h2 id="contact-title">Contact</h2>
+    </header>
   </div>
 </section>

--- a/partials/footer.html
+++ b/partials/footer.html
@@ -7,6 +7,5 @@
       <a href="#products">Products</a>
       <a href="#contact">Contact</a>
     </nav>
-    <div>&copy; NIOS Cloud Solutions Ltd.</div>
   </div>
 </footer>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,8 +1,6 @@
 <header class="site-header" role="banner">
   <div class="shell site-header__inner" aria-label="Top navigation">
-    <a class="brand" href="#home" aria-label="NIOS home">
-      <img src="images/NIOSLogoWithTextLarge.png" alt="NIOS Logo" class="brand-logo" />
-    </a>
+    <a class="brand" href="#home">NIOS</a>
     <nav class="site-nav" aria-label="Primary navigation">
       <ul class="site-nav__list">
         <li><a href="#home">Home</a></li>
@@ -12,9 +10,6 @@
         <li><a href="#contact">Contact</a></li>
       </ul>
     </nav>
-    <div class="site-header__actions">
-      <a href="mailto:info@nios-cloud.com">info@nios-cloud.com</a>
-    </div>
     <button id="menuToggle" class="menu-toggle" type="button" aria-controls="mobileNav" aria-expanded="false">
       <span class="sr-only">Toggle navigation</span>
       <span class="menu-toggle__icon" aria-hidden="true"></span>
@@ -31,9 +26,5 @@
       <li><a href="#products">Products</a></li>
       <li><a href="#contact">Contact</a></li>
     </ul>
-    <div class="mobile-drawer__meta">
-      <a href="mailto:info@nios-cloud.com">info@nios-cloud.com</a>
-      <a href="#" data-close data-exit>Close menu</a>
-    </div>
   </div>
 </nav>

--- a/partials/hero.html
+++ b/partials/hero.html
@@ -1,43 +1,7 @@
 <section class="section hero reveal">
-  <div class="shell hero__layout">
-    <div class="hero__content">
-      <span class="section__eyebrow hero__kicker">Microsoft-first partner</span>
-      <h1>Unlock modern operations with Power Platform, Dynamics 365 and Microsoft 365 experts</h1>
-      <p class="hero__lede">NIOS delivers Microsoft-based consultancy and solution delivery that connects Power Platform, Dynamics 365 Customer Engagement, SharePoint and Teams so your people can work smarter, faster.</p>
-      <ul class="hero__points">
-        <li>
-          <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-            <path d="M9.00001 16.17L4.83001 12l-1.41 1.41L9.00001 19 21 7.00001l-1.41-1.41z" />
-          </svg>
-          Accelerators for Timesheets and Expenses ready for Dataverse, Dataverse for Teams or SharePoint.
-        </li>
-        <li>
-          <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-            <path d="M9.00001 16.17L4.83001 12l-1.41 1.41L9.00001 19 21 7.00001l-1.41-1.41z" />
-          </svg>
-          End-to-end engagements across discovery, solution design, build and adoption.
-        </li>
-        <li>
-          <svg aria-hidden="true" focusable="false" viewBox="0 0 24 24">
-            <path d="M9.00001 16.17L4.83001 12l-1.41 1.41L9.00001 19 21 7.00001l-1.41-1.41z" />
-          </svg>
-          Hybrid delivery blending low-code agility with pro-code extensibility when you need it most.
-        </li>
-      </ul>
-      <div class="hero__actions">
-        <a class="button button--accent" href="#contact">Plan a discovery call</a>
-        <a class="button button--ghost" href="#products">Review solution accelerators</a>
-      </div>
-    </div>
-    <div class="hero__media">
-      <figure class="media-placeholder" data-variant="portrait">
-        <span class="badge badge--muted media-placeholder__badge">Preview</span>
-        <img src="images/mockup-placeholder.svg" alt="Simplified illustration of a Power Platform workspace" loading="lazy" />
-      </figure>
-      <div class="hero__note">
-        <span class="badge badge--muted">Next steps</span>
-        <p>Prefer a guided walkthrough? Let us know and we’ll tailor a demo around your use case.</p>
-      </div>
-    </div>
+  <div class="shell">
+    <header class="section__header">
+      <h1>Hero</h1>
+    </header>
   </div>
 </section>

--- a/partials/products.html
+++ b/partials/products.html
@@ -1,56 +1,7 @@
 <section id="products" class="section reveal">
   <div class="shell">
     <header class="section__header">
-      <span class="section__eyebrow">Solution blueprints</span>
-      <h2>Power Platform business apps ready for rapid rollout</h2>
-      <p class="section__lede">Deploy as-is or tailor to your teams — each accelerator includes the data model, automations and governance guidance to get moving quickly.</p>
+      <h2>Products</h2>
     </header>
-    <div class="product-list">
-      <article class="product-card">
-        <div>
-          <h3>Timesheets App</h3>
-          <p>Track utilisation, approvals and insights with an accelerator built for consulting, engineering and service teams.</p>
-          <ul class="product-card__meta" aria-label="Timesheets App deployment options">
-            <li>Dataverse</li>
-            <li>Dataverse for Teams</li>
-            <li>SharePoint</li>
-            <li>Out-of-the-box or customised</li>
-          </ul>
-          <ul>
-            <li>Mobile-first capture with configurable projects, tasks and rate cards.</li>
-            <li>Approval workflows with reminders, escalations and audit history.</li>
-            <li>Dashboards for utilisation, billable hours and compliance trends.</li>
-          </ul>
-        </div>
-        <figure class="media-placeholder" data-variant="panoramic">
-          <span class="badge badge--muted media-placeholder__badge">Available</span>
-          <img src="images/mockup-placeholder.svg" alt="Simplified illustration of the Timesheets App interface" loading="lazy" />
-        </figure>
-      </article>
-      <article class="product-card">
-        <div>
-          <h3>Expenses App</h3>
-          <p>Digitise receipt capture, automate approvals and give finance live visibility over spend.</p>
-          <ul class="product-card__meta" aria-label="Expenses App deployment options">
-            <li>Dataverse</li>
-            <li>Dataverse for Teams</li>
-            <li>SharePoint</li>
-            <li>Out-of-the-box or customised</li>
-          </ul>
-          <ul>
-            <li>Guided submission journeys for desktop and mobile users.</li>
-            <li>Flexible routing rules, policy checks and exception handling.</li>
-            <li>Real-time analytics for spend trends, reimbursement status and audit trails.</li>
-          </ul>
-        </div>
-        <figure class="media-placeholder" data-variant="panoramic">
-          <span class="badge badge--muted media-placeholder__badge">Available</span>
-          <img src="images/mockup-placeholder.svg" alt="Simplified illustration of the Expenses App interface" loading="lazy" />
-        </figure>
-      </article>
-    </div>
-    <p class="section__lede" style="margin-top: clamp(1.5rem,3.5vw,2.5rem); font-size:0.95rem;">
-      <em>Need something bespoke? We extend each accelerator with advanced integrations, reporting and governance to match your roadmap.</em>
-    </p>
   </div>
 </section>

--- a/partials/services.html
+++ b/partials/services.html
@@ -1,75 +1,7 @@
 <section id="services" class="section reveal">
   <div class="shell">
     <header class="section__header">
-      <span class="section__eyebrow">Services</span>
-      <h2>Design, build and evolve every part of your Microsoft platform</h2>
-      <p class="section__lede">Strategy, architecture and delivery work together so your organisation adopts Microsoft-powered solutions that keep improving.</p>
+      <h2>Services</h2>
     </header>
-    <div class="feature-grid" role="list">
-      <article class="feature-card" role="listitem">
-        <div class="feature-card__header">
-          <span class="feature-card__icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24"><rect x="3" y="3" width="8" height="8" rx="2" /><rect x="13" y="3" width="8" height="8" rx="2" /><rect x="3" y="13" width="8" height="8" rx="2" /><rect x="13" y="13" width="8" height="8" rx="2" /></svg>
-          </span>
-          <div>
-            <h3>Power Platform solutions</h3>
-            <p>Canvas, model-driven and automated experiences shaped around your teams and data.</p>
-          </div>
-        </div>
-        <ul class="feature-card__list">
-          <li>Discovery-led design across Power Apps, Power Automate and Power BI.</li>
-          <li>Dataverse, Dataverse for Teams or SharePoint as the right-sized foundation.</li>
-          <li>Governed ALM with deployment pipelines and environment strategy.</li>
-        </ul>
-      </article>
-      <article class="feature-card" role="listitem">
-        <div class="feature-card__header">
-          <span class="feature-card__icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24"><circle cx="6" cy="6" r="3" /><circle cx="18" cy="6" r="3" /><circle cx="12" cy="18" r="3" /><path d="M9 6h6M6 9l4 7M18 9l-4 7" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg>
-          </span>
-          <div>
-            <h3>Dynamics 365 Customer Engagement</h3>
-            <p>Optimise sales, service and case management with connected Microsoft cloud tooling.</p>
-          </div>
-        </div>
-        <ul class="feature-card__list">
-          <li>Dataverse modelling, integrations and workflow design tailored to your roles.</li>
-          <li>Embedded Teams, Outlook and Power Automate experiences for users.</li>
-          <li>Roadmaps for migrating from legacy CRM or enhancing existing deployments.</li>
-        </ul>
-      </article>
-      <article class="feature-card" role="listitem">
-        <div class="feature-card__header">
-          <span class="feature-card__icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24"><circle cx="8" cy="12" r="4" /><rect x="13" y="8" width="8" height="10" rx="2" /><path d="M15 9h4M15 12h4M15 15h4" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg>
-          </span>
-          <div>
-            <h3>SharePoint &amp; Microsoft Teams</h3>
-            <p>Modern work hubs that surface the right content, processes and conversations.</p>
-          </div>
-        </div>
-        <ul class="feature-card__list">
-          <li>SharePoint sites, lists and knowledge bases aligned to business outcomes.</li>
-          <li>Teams apps, approvals and Viva integrations to streamline collaboration.</li>
-          <li>Governance and lifecycle planning that keeps your estate organised.</li>
-        </ul>
-      </article>
-      <article class="feature-card" role="listitem">
-        <div class="feature-card__header">
-          <span class="feature-card__icon" aria-hidden="true">
-            <svg viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="12" rx="2" /><path d="M6 18h12" fill="none" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" /></svg>
-          </span>
-          <div>
-            <h3>Advisory &amp; enablement</h3>
-            <p>Governance, upskilling and support services that help your teams own the platform.</p>
-          </div>
-        </div>
-        <ul class="feature-card__list">
-          <li>Platform governance frameworks and licensing guidance.</li>
-          <li>Role-based training and centre of excellence mentoring.</li>
-          <li>Managed enhancements and support aligned to your roadmap.</li>
-        </ul>
-      </article>
-    </div>
   </div>
 </section>

--- a/styles/main.css
+++ b/styles/main.css
@@ -1,99 +1,52 @@
-/* =========================================================
-   Base styles & typography
-   ========================================================= */
-
+/* Base */
 * {
   box-sizing: border-box;
-}
-
-html {
-  scroll-behavior: smooth;
-}
-
-html:focus-within {
-  scroll-behavior: smooth;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
-  background: var(--nios-color-background) url('../images/NIOSback.png') no-repeat center / cover fixed;
-  color: var(--nios-color-text);
-  font-family: var(--nios-font-body);
-  line-height: 1.6;
+  background: var(--color-background);
+  color: var(--color-text);
+  font-family: var(--font-base);
+  line-height: 1.5;
 }
 
 img,
 svg {
+  display: block;
   max-width: 100%;
   height: auto;
-  display: block;
-}
-
-figure {
-  margin: 0;
 }
 
 a {
   color: inherit;
+  text-decoration: none;
 }
 
 a:hover,
 a:focus-visible {
-  color: inherit;
+  text-decoration: underline;
 }
 
-p {
-  margin: 0 0 0.85rem;
-  color: var(--nios-color-text-muted);
+a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
-
-h1,
-h2,
-h3,
-h4 {
-  color: var(--nios-color-text);
-  line-height: 1.2;
-  margin: 0 0 1rem;
-  text-wrap: balance;
-}
-
-h1 { font-size: clamp(2.1rem, 4vw, 3rem); }
-h2 { font-size: clamp(1.8rem, 3vw, 2.5rem); }
-h3 { font-size: clamp(1.3rem, 2vw, 1.6rem); }
-
-/* =========================================================
-   Accessibility helpers
-   ========================================================= */
 
 .skip-link {
   position: absolute;
-  left: -999px;
-  top: auto;
-  width: 1px;
-  height: 1px;
-  overflow: hidden;
+  inset: 1rem auto auto 1rem;
+  padding: 0.5rem 1rem;
+  background: var(--color-accent);
+  color: var(--color-background);
+  transform: translateY(-150%);
+  transition: transform 0.2s ease;
+  z-index: 10;
 }
 
 .skip-link:focus {
-  left: 1rem;
-  top: 1rem;
-  width: auto;
-  height: auto;
-  z-index: 999;
-  padding: 0.5rem 0.75rem;
-  background: var(--nios-color-text);
-  color: var(--nios-color-surface);
-  border-radius: var(--nios-radius-sm);
-}
-
-:focus-visible {
-  outline: 3px solid var(--nios-color-ring);
-  outline-offset: 3px;
-}
-
-:focus:not(:focus-visible) {
-  outline: none;
+  transform: translateY(0);
 }
 
 .sr-only {
@@ -108,843 +61,151 @@ h3 { font-size: clamp(1.3rem, 2vw, 1.6rem); }
   border: 0;
 }
 
-/* =========================================================
-   Layout helpers
-   ========================================================= */
-
 .shell {
-  width: min(100% - 2.5rem, var(--nios-max-width));
-  margin: 0 auto;
+  width: min(100% - 2rem, var(--max-width));
+  margin-inline: auto;
 }
 
 .section {
-  padding-block: clamp(40px, 8vw, var(--nios-section-space));
-}
-
-.section--surface {
-  background: color-mix(in srgb, var(--nios-color-surface) 80%, transparent);
-  border-radius: clamp(24px, 4vw, 36px);
-  box-shadow: var(--nios-shadow-card);
+  padding-block: var(--section-space);
 }
 
 .section__header {
-  max-width: 60ch;
-  margin-bottom: clamp(1.5rem, 5vw, 2.5rem);
   display: grid;
   gap: 0.75rem;
 }
 
-.section__eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.3rem 0.75rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--nios-color-accent) 55%, white);
-  color: var(--nios-color-text);
-  font-weight: 600;
-  font-size: 0.85rem;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-}
-
-.section__lede {
-  font-size: clamp(1.05rem, 2vw, 1.2rem);
-  color: var(--nios-color-text-muted);
-  margin: 0;
-  max-width: 50ch;
-}
-
-.grid {
-  display: grid;
-  gap: var(--nios-grid-gap);
-}
-
-.split {
-  display: grid;
-  gap: var(--nios-grid-gap);
-}
-
-@media (min-width: 960px) {
-  .split {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    align-items: center;
-  }
-}
-
-/* =========================================================
-   Buttons & badges
-   ========================================================= */
-
-.button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.65rem;
-  padding: 0.95rem 1.6rem;
-  border-radius: 999px;
-  border: 2px solid transparent;
-  background: var(--nios-color-text);
-  color: var(--nios-color-surface);
-  font-weight: 600;
-  font-size: 1rem;
-  line-height: 1;
-  text-decoration: none;
-  box-shadow: var(--nios-shadow-card);
-  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease, color 0.2s ease;
-}
-
-.button svg {
-  width: 1.15rem;
-  height: 1.15rem;
-  fill: currentColor;
-}
-
-.button:hover,
-.button:focus-visible {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.12);
-}
-
-.button--ghost {
-  background: transparent;
-  color: var(--nios-color-text);
-  border-color: color-mix(in srgb, var(--nios-color-text) 20%, transparent);
-  box-shadow: none;
-}
-
-.button--ghost:hover,
-.button--ghost:focus-visible {
-  background: color-mix(in srgb, var(--nios-color-text) 6%, transparent);
-  box-shadow: none;
-}
-
-.button--accent {
-  background: var(--nios-color-accent);
-  color: var(--nios-color-text);
-}
-
-.button--accent:hover,
-.button--accent:focus-visible {
-  background: color-mix(in srgb, var(--nios-color-accent) 90%, white);
-}
-
-.badge {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.25rem 0.75rem;
-  border-radius: 999px;
-  background: var(--nios-color-text);
-  color: var(--nios-color-surface);
-  font-weight: 600;
-  font-size: 0.8rem;
-  letter-spacing: 0.02em;
-  text-transform: uppercase;
-}
-
-.badge--muted {
-  background: color-mix(in srgb, var(--nios-color-text) 12%, transparent);
-  color: var(--nios-color-text);
-}
-
-/* =========================================================
-   Header & primary navigation
-   ========================================================= */
-
+/* Header */
 .site-header {
-  position: sticky;
-  top: 0;
-  inset-inline: 0;
-  z-index: 1000;
-  backdrop-filter: saturate(120%) blur(12px);
-  background: rgba(255, 255, 255, 0.92);
-  border-bottom: 1px solid color-mix(in srgb, var(--nios-color-surface-muted) 65%, transparent);
+  background: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .site-header__inner {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  gap: 1.5rem;
-  min-height: clamp(72px, 10vw, 92px);
+  gap: 1rem;
+  padding-block: 1rem;
 }
 
 .brand {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.75rem;
-  text-decoration: none;
-  color: var(--nios-color-text);
-  min-width: 0;
-}
-
-.brand-logo {
-  width: clamp(180px, 28vw, 220px);
-  height: auto;
-}
-
-.site-nav {
-  display: none;
+  font-size: 1.1rem;
+  font-weight: 600;
 }
 
 .site-nav__list {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 1rem;
   list-style: none;
   margin: 0;
   padding: 0;
 }
 
-.site-nav a {
-  display: inline-flex;
-  padding: 0.65rem 0.9rem;
-  border-radius: 999px;
-  text-decoration: none;
-  color: var(--nios-color-text);
-  font-weight: 500;
-}
-
-.site-nav a:hover,
-.site-nav a:focus-visible {
-  background: color-mix(in srgb, var(--nios-color-text) 8%, transparent);
-}
-
-.site-header__actions {
+.menu-toggle {
   display: none;
   align-items: center;
-  gap: 0.75rem;
-  font-weight: 600;
-}
-
-.site-header__actions a {
-  text-decoration: none;
-  color: var(--nios-color-text);
-}
-
-.menu-toggle {
-  position: relative;
-  width: 46px;
-  height: 46px;
-  border-radius: 50%;
-  border: 1px solid color-mix(in srgb, var(--nios-color-text) 15%, transparent);
-  background: color-mix(in srgb, var(--nios-color-surface) 90%, transparent);
-  cursor: pointer;
-  transition: background-color 0.2s ease, transform 0.2s ease;
-}
-
-.menu-toggle:hover,
-.menu-toggle:focus-visible {
-  transform: scale(1.02);
-  background: color-mix(in srgb, var(--nios-color-text) 6%, var(--nios-color-surface));
-}
-
-.menu-toggle__icon,
-.menu-toggle__icon::before,
-.menu-toggle__icon::after {
-  content: '';
-  position: absolute;
-  left: 50%;
-  width: 18px;
-  height: 2px;
-  background: var(--nios-color-text);
-  border-radius: 999px;
-  transform: translateX(-50%);
-  transition: transform 0.3s ease, opacity 0.3s ease;
+  justify-content: center;
+  padding: 0.5rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: transparent;
+  font: inherit;
 }
 
 .menu-toggle__icon {
-  top: 50%;
-}
-
-.menu-toggle__icon::before {
-  top: -6px;
+  width: 1.25rem;
+  height: 1.25rem;
+  border-top: 2px solid currentColor;
+  border-bottom: 2px solid currentColor;
+  position: relative;
 }
 
 .menu-toggle__icon::after {
-  top: 6px;
+  content: "";
+  position: absolute;
+  inset: 50% 0 auto;
+  height: 2px;
+  background: currentColor;
+  transform: translateY(-50%);
 }
 
-.menu-toggle[aria-expanded="true"] .menu-toggle__icon {
-  background: transparent;
-}
-
-.menu-toggle[aria-expanded="true"] .menu-toggle__icon::before {
-  top: 0;
-  transform: translate(-50%, 0) rotate(45deg);
-}
-
-.menu-toggle[aria-expanded="true"] .menu-toggle__icon::after {
-  top: 0;
-  transform: translate(-50%, 0) rotate(-45deg);
-}
-
-@media (min-width: 960px) {
-  .site-nav { display: block; }
-  .site-header__actions { display: inline-flex; }
-  .menu-toggle { display: none; }
-}
-
-/* =========================================================
-   Mobile drawer navigation
-   ========================================================= */
-
+/* Mobile navigation */
 .mobile-drawer {
   position: fixed;
   inset: 0;
-  display: grid;
-  place-items: end;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 900;
-  opacity: 0;
-  visibility: hidden;
-  pointer-events: none;
-  transition: opacity 0.3s ease, visibility 0.3s ease;
+  display: none;
+  background: rgba(0, 0, 0, 0.45);
 }
 
 .mobile-drawer.open {
-  opacity: 1;
-  visibility: visible;
-  pointer-events: auto;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .mobile-drawer__panel {
-  background: var(--nios-color-surface);
-  color: var(--nios-color-text);
-  width: min(100%, 360px);
-  padding: 2.25rem 1.75rem 2.5rem;
-  border-radius: var(--nios-radius-lg) 0 0 0;
-  box-shadow: var(--nios-shadow-lg);
-  transform: translateY(12px);
-  transition: transform 0.3s ease;
-}
-
-.mobile-drawer.open .mobile-drawer__panel {
-  transform: translateY(0);
+  width: min(320px, 80vw);
+  height: 100%;
+  background: var(--color-background);
+  padding: 1.5rem;
+  display: grid;
+  gap: 1.5rem;
 }
 
 .mobile-drawer__close {
-  position: absolute;
-  top: 1.5rem;
-  right: 1.5rem;
-  border: 0;
+  margin-left: auto;
   background: none;
-  color: inherit;
-  font-size: 1.4rem;
-  cursor: pointer;
+  border: 0;
+  font-size: 1.5rem;
+  line-height: 1;
 }
 
 .mobile-drawer__list {
   list-style: none;
-  display: grid;
-  gap: 1rem;
   margin: 0;
   padding: 0;
-}
-
-.mobile-drawer__list a {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  text-decoration: none;
-  color: var(--nios-color-text);
-  font-size: 1.1rem;
-  font-weight: 600;
-}
-
-.mobile-drawer__meta {
-  margin-top: 2.5rem;
-  padding-top: 1.5rem;
-  border-top: 1px solid color-mix(in srgb, var(--nios-color-text) 10%, transparent);
-  display: grid;
-  gap: 0.75rem;
-}
-
-.mobile-drawer__meta a {
-  font-weight: 600;
-  text-decoration: none;
-  color: var(--nios-color-text);
-}
-
-/* =========================================================
-   Hero
-   ========================================================= */
-
-.hero {
-  padding-top: clamp(48px, 10vw, 96px);
-}
-
-.hero__layout {
-  display: grid;
-  gap: var(--nios-grid-gap);
-}
-
-.hero__content {
-  display: grid;
-  gap: clamp(1rem, 2.5vw, 1.5rem);
-  max-width: 560px;
-}
-
-@media (min-width: 1024px) {
-  .hero__layout {
-    grid-template-columns: minmax(0, 1.2fr) minmax(0, 1fr);
-    align-items: center;
-  }
-}
-
-.hero__kicker {
-  margin-bottom: 1rem;
-}
-
-.hero__lede {
-  font-size: clamp(1.1rem, 2vw, 1.3rem);
-  margin-bottom: 1.5rem;
-}
-
-.hero__points {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 1.5rem;
-  display: grid;
-  gap: 0.65rem;
-}
-
-.hero__points li {
-  display: inline-flex;
-  align-items: flex-start;
-  gap: 0.65rem;
-  color: var(--nios-color-text-muted);
-}
-
-.hero__points svg {
-  width: 1.1rem;
-  height: 1.1rem;
-  margin-top: 0.2rem;
-  flex-shrink: 0;
-  fill: var(--nios-color-accent);
-}
-
-.hero__actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.65rem;
-  width: 100%;
-}
-
-.hero__actions .button {
-  flex: 1 1 220px;
-}
-
-@media (min-width: 720px) {
-  .hero__actions {
-    width: auto;
-  }
-
-  .hero__actions .button {
-    flex: 0 0 auto;
-  }
-}
-
-.hero__media {
-  display: grid;
-  gap: 1rem;
-  justify-items: start;
-}
-
-.hero__note {
-  background: color-mix(in srgb, var(--nios-color-surface-muted) 60%, white);
-  border-radius: var(--nios-radius-lg);
-  padding: 1rem 1.25rem;
-  box-shadow: var(--nios-shadow-sm);
-  color: var(--nios-color-text);
-  font-size: 0.95rem;
-}
-
-.hero__note p {
-  color: inherit;
-  margin: 0.35rem 0 0;
-}
-
-/* =========================================================
-   Media placeholder utility
-   ========================================================= */
-
-.media-placeholder {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 4 / 3;
-  border-radius: clamp(20px, 4vw, 28px);
-  background: linear-gradient(140deg, color-mix(in srgb, var(--nios-color-accent) 25%, white), color-mix(in srgb, var(--nios-color-surface-muted) 65%, white));
-  box-shadow: var(--nios-shadow-card);
-  overflow: hidden;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: clamp(1.25rem, 3vw, 2rem);
-}
-
-.media-placeholder img {
-  width: 100%;
-  height: auto;
-  opacity: 0.95;
-}
-
-.media-placeholder[data-variant="panoramic"] {
-  aspect-ratio: 16 / 9;
-}
-
-.media-placeholder[data-variant="portrait"] {
-  aspect-ratio: 3 / 4;
-}
-
-.media-placeholder__badge {
-  position: absolute;
-  inset: 1.25rem auto auto 1.25rem;
-}
-
-/* =========================================================
-   About section
-   ========================================================= */
-
-.about__layout {
-  display: grid;
-  gap: clamp(1.5rem, 4vw, 2.5rem);
-}
-
-@media (min-width: 960px) {
-  .about__layout {
-    grid-template-columns: minmax(0, 1.1fr) minmax(0, 0.9fr);
-    align-items: start;
-  }
-}
-
-.about__intro {
-  display: grid;
-  gap: 1.25rem;
-}
-
-.about__list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.75rem;
-}
-
-.about__list li {
-  position: relative;
-  padding-left: 1.5rem;
-  color: var(--nios-color-text-muted);
-}
-
-.about__list li::before {
-  content: '';
-  position: absolute;
-  top: 0.55rem;
-  left: 0;
-  width: 0.6rem;
-  height: 0.6rem;
-  border-radius: 999px;
-  background: var(--nios-color-accent);
-}
-
-.about__pillars {
   display: grid;
   gap: 1rem;
 }
 
-@media (min-width: 720px) {
-  .about__pillars {
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-  }
-}
-
-.about-card {
-  background: color-mix(in srgb, var(--nios-color-surface-muted) 50%, white);
-  border-radius: var(--nios-radius-lg);
-  padding: clamp(1.5rem, 4vw, 2.25rem);
-  box-shadow: var(--nios-shadow-sm);
-  display: grid;
-  gap: 0.5rem;
-}
-
-.about-card h3 {
-  margin: 0;
-  font-size: clamp(1.2rem, 2vw, 1.4rem);
-}
-
-.about-card p {
-  margin: 0;
-}
-
-/* =========================================================
-   Services
-   ========================================================= */
-
-.feature-grid {
-  display: grid;
-  gap: var(--nios-grid-gap);
-}
-
-@media (min-width: 720px) {
-  .feature-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media (min-width: 1160px) {
-  .feature-grid {
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-  }
-}
-
-.feature-card {
-  background: color-mix(in srgb, var(--nios-color-surface) 85%, transparent);
-  border-radius: var(--nios-radius-lg);
-  box-shadow: var(--nios-shadow-card);
-  padding: clamp(1.5rem, 4vw, 2rem);
-  display: grid;
-  gap: 1.1rem;
-}
-
-.feature-card__header {
-  display: flex;
-  flex-direction: column;
-  align-items: flex-start;
-  gap: 0.75rem;
-}
-
-@media (min-width: 520px) {
-  .feature-card__header {
-    flex-direction: row;
-    align-items: center;
-  }
-}
-
-.feature-card__icon {
-  flex-shrink: 0;
-  width: 52px;
-  height: 52px;
-  border-radius: 16px;
-  background: color-mix(in srgb, var(--nios-color-accent) 65%, white);
-  display: grid;
-  place-items: center;
-}
-
-.feature-card__icon svg {
-  width: 26px;
-  height: 26px;
-  fill: var(--nios-color-text);
-}
-
-.feature-card__icon svg * {
-  fill: var(--nios-color-text);
-  stroke: var(--nios-color-text);
-}
-
-.feature-card p {
-  margin: 0;
-}
-
-.feature-card__list {
-  margin: 0;
-  padding-left: 1.1rem;
-  display: grid;
-  gap: 0.35rem;
-  color: var(--nios-color-text-muted);
-  font-size: 0.95rem;
-}
-
-/* =========================================================
-   Products
-   ========================================================= */
-
-.product-list {
-  display: grid;
-  gap: var(--nios-grid-gap);
-}
-
-.product-card {
-  display: grid;
-  gap: clamp(1.5rem, 4vw, 2rem);
-  align-items: start;
-  background: color-mix(in srgb, var(--nios-color-surface) 88%, transparent);
-  border-radius: clamp(24px, 4vw, 32px);
-  padding: clamp(1.75rem, 4vw, 2.5rem);
-  box-shadow: var(--nios-shadow-card);
-}
-
-@media (min-width: 980px) {
-  .product-card {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 0.9fr);
-  }
-}
-
-.product-card h3 {
-  margin-bottom: 0.75rem;
-}
-
-.product-card ul {
-  margin: 1rem 0 0;
-  padding-left: 1.25rem;
-  color: var(--nios-color-text-muted);
-}
-
-.product-card__badge {
-  inset: auto 1.25rem 1.25rem auto;
-}
-
-.product-card__meta {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-}
-
-.product-card__meta li {
-  padding: 0.3rem 0.75rem;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--nios-color-text) 10%, transparent);
-  color: var(--nios-color-text);
-  font-weight: 600;
-  font-size: 0.8rem;
-  letter-spacing: 0.01em;
-}
-
-/* =========================================================
-   Contact
-   ========================================================= */
-
-.contact {
-  background: color-mix(in srgb, var(--nios-color-surface) 85%, transparent);
-  border-radius: clamp(26px, 4vw, 34px);
-  box-shadow: var(--nios-shadow-card);
-  padding: clamp(2rem, 6vw, 3rem);
-}
-
-.contact__grid {
-  display: grid;
-  gap: var(--nios-grid-gap);
-}
-
-@media (min-width: 880px) {
-  .contact__grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-.contact-card {
-  background: color-mix(in srgb, var(--nios-color-surface-muted) 60%, white);
-  border-radius: var(--nios-radius-lg);
-  padding: clamp(1.5rem, 4vw, 2.25rem);
-  box-shadow: var(--nios-shadow-sm);
-  display: grid;
-  gap: 1rem;
-}
-
-.contact-card p {
-  margin: 0;
-}
-
-.contact-list {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-  display: grid;
-  gap: 0.75rem;
-}
-
-.contact-list a {
-  font-weight: 600;
-  color: var(--nios-color-text);
-  text-decoration: none;
-}
-
-.contact-placeholder {
-  background: color-mix(in srgb, var(--nios-color-surface) 80%, transparent);
-  border-radius: var(--nios-radius-lg);
-  border: 2px dashed color-mix(in srgb, var(--nios-color-text) 15%, transparent);
-  padding: clamp(1.75rem, 4vw, 2.5rem);
-  display: grid;
-  gap: 0.75rem;
-}
-
-.contact-placeholder p {
-  margin: 0;
-}
-
-/* =========================================================
-   Footer
-   ========================================================= */
-
+/* Footer */
 footer {
-  margin-top: clamp(4rem, 8vw, 6rem);
-  padding: 3rem 0 4rem;
-  border-top: 1px solid color-mix(in srgb, var(--nios-color-text) 10%, transparent);
-  color: var(--nios-color-text-muted);
-  font-size: 0.95rem;
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface);
 }
 
 .footer__inner {
-  display: grid;
-  gap: 1.5rem;
-  text-align: center;
+  padding-block: 1.5rem;
+  display: flex;
+  justify-content: center;
 }
 
 .footer-nav {
   display: flex;
   flex-wrap: wrap;
-  justify-content: center;
-  gap: 0.75rem;
-  margin: 0;
-  padding: 0;
-  list-style: none;
+  gap: 1rem;
 }
 
-.footer-nav a {
-  text-decoration: none;
-  color: inherit;
-  padding: 0.35rem 0.85rem;
-  border-radius: 999px;
-}
-
-.footer-nav a:hover,
-.footer-nav a:focus-visible {
-  background: color-mix(in srgb, var(--nios-color-text) 8%, transparent);
-  color: var(--nios-color-text);
-}
-
-/* =========================================================
-   Motion helpers
-   ========================================================= */
-
+/* Reveal helper */
 .reveal {
   opacity: 0;
-  transform: translateY(16px);
+  transform: translateY(12px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
 }
 
-.reveal.revealed {
+.revealed {
   opacity: 1;
-  transform: none;
-  transition: opacity 0.6s ease, transform 0.6s ease;
+  transform: translateY(0);
 }
 
-@media (prefers-reduced-motion: reduce) {
-  html { scroll-behavior: auto; }
-  .reveal { opacity: 1; transform: none; }
-  .reveal.revealed { transition: none; }
-}
+/* Responsive */
+@media (max-width: 768px) {
+  .site-nav {
+    display: none;
+  }
 
-/* =========================================================
-   Responsive background adjustment
-   ========================================================= */
-
-@media (max-width: 899px) {
-  body {
-    background-image: url('../images/NIOSmobilebackground.jpg');
-    background-attachment: scroll;
+  .menu-toggle {
+    display: inline-flex;
   }
 }

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,19 +1,11 @@
 :root {
-  --nios-color-background: #F2F2F2;
-  --nios-color-surface: #FFFFFF;
-  --nios-color-surface-muted: #E4F2E6;
-  --nios-color-text: #253140;
-  --nios-color-text-muted: #656B73;
-  --nios-color-accent: #A9D9A7;
-  --nios-color-ring: #A9D9A7;
-  --nios-color-ring-strong: #253140;
-  --nios-radius-sm: 12px;
-  --nios-radius-lg: 18px;
-  --nios-shadow-sm: 0 1px 4px rgba(0, 0, 0, 0.06);
-  --nios-shadow-lg: 0 20px 40px rgba(0, 0, 0, 0.08);
-  --nios-shadow-card: 0 8px 32px rgba(0, 0, 0, 0.08), 0 2px 12px rgba(0, 0, 0, 0.06);
-  --nios-max-width: 1160px;
-  --nios-grid-gap: clamp(1.25rem, 1.8vw, 1.75rem);
-  --nios-section-space: clamp(56px, 9vw, 96px);
-  --nios-font-body: "Segoe UI", "Helvetica Neue", Arial, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI Emoji", sans-serif;
+  --color-background: #ffffff;
+  --color-surface: #f5f5f5;
+  --color-text: #1f2933;
+  --color-accent: #111827;
+  --color-border: #d0d7de;
+  --radius-sm: 8px;
+  --max-width: 960px;
+  --section-space: clamp(3rem, 8vw, 6rem);
+  --font-base: "Segoe UI", "Helvetica Neue", Arial, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI Emoji", sans-serif;
 }


### PR DESCRIPTION
## Summary
- replace the landing page metadata with neutral template copy and retain modular partial includes
- strip each partial down to minimal heading-only sections to provide a clean starting point
- simplify the design tokens and main stylesheet to lightweight base layout and navigation styles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68e0ee3c18208329a9948bfea067bf8d