### PR TITLE
Fix mobile menu overlay stacking order

### DIFF
--- a/styles/main.css
+++ b/styles/main.css
@@ -665,6 +665,7 @@ textarea {
   display: none;
   background: rgba(15, 23, 42, 0.45);
   backdrop-filter: blur(6px);
+  z-index: 60;
 }
 
 .mobile-drawer.open {


### PR DESCRIPTION
## Summary
- ensure the mobile navigation drawer renders above page content by increasing its z-index

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5669eb9d483298c0352e2df37d7e6