### PR TITLE
Integrate new logo and icon assets

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
     <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" />
     <link rel="stylesheet" href="styles/tokens.css" />
     <link rel="stylesheet" href="styles/main.css" />
-    <link rel="icon" href='data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="6" fill="%23A9D9A7"/></svg>' />
+    <link rel="icon" type="image/png" href="images/F1E7103A-3051-4A06-B15A-9B52CEB2F38B.png" />
     <script src="scripts/main.js" type="module" defer></script>
   </head>
   <body>

--- a/partials/header.html
+++ b/partials/header.html
@@ -1,6 +1,13 @@
 <header class="site-header" role="banner">
   <div class="shell site-header__inner" aria-label="Top navigation">
-    <a class="brand" href="#home">NIOS</a>
+    <a class="brand brand--logo" href="#home">
+      <img
+        class="brand__logo"
+        src="images/82C655D8-8428-4FE1-9B39-2418246B5B42.png"
+        alt="NIOS Consulting"
+      />
+      <span class="brand__text" aria-hidden="true">NIOS</span>
+    </a>
     <nav class="site-nav" aria-label="Primary navigation">
       <ul class="site-nav__list">
         <li><a href="#home">Home</a></li>

--- a/partials/hero.html
+++ b/partials/hero.html
@@ -26,11 +26,12 @@
     <div class="hero__media" aria-hidden="true">
       <div class="hero__card">
         <span class="hero__icon" aria-hidden="true">
-          <svg viewBox="0 0 64 64" role="img" focusable="false" aria-hidden="true">
-            <path d="M8 22.5 28 10l20 12.5v19L28 54 8 41.5z" fill="none" stroke="currentColor" stroke-width="3" stroke-linejoin="round"/>
-            <path d="M28 54V35" fill="none" stroke="currentColor" stroke-width="3" stroke-linecap="round"/>
-            <path d="m28 20 12 7.5-12 7.5-12-7.5z" fill="currentColor" opacity="0.18"/>
-          </svg>
+          <img
+            class="hero__icon-image"
+            src="images/F1E7103A-3051-4A06-B15A-9B52CEB2F38B.png"
+            alt=""
+            loading="lazy"
+          />
         </span>
         <p class="hero__card-title">From pilot to enterprise scale</p>
         <p class="hero__card-copy">Reusable accelerators, governance playbooks, and adoption specialists included in every engagement.</p>

--- a/styles/main.css
+++ b/styles/main.css
@@ -181,9 +181,33 @@ p {
 }
 
 .brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
   font-size: 1.35rem;
   font-weight: 700;
   letter-spacing: -0.02em;
+  line-height: 1;
+  color: inherit;
+  text-decoration: none;
+}
+
+.brand__logo {
+  display: block;
+  height: clamp(32px, 4vw, 44px);
+  width: auto;
+  object-fit: contain;
+}
+
+.brand__text {
+  font: inherit;
+  letter-spacing: inherit;
+}
+
+.brand:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 4px;
+  border-radius: 6px;
 }
 
 .site-nav__list {
@@ -356,15 +380,17 @@ p {
   width: 64px;
   height: 64px;
   border-radius: 18px;
-  background: rgba(255, 255, 255, 0.12);
+  background: #fff;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
   display: grid;
   place-items: center;
 }
 
-.hero__icon svg {
-  width: 40px;
-  height: 40px;
-  color: #bfdbfe;
+.hero__icon-image {
+  width: 70%;
+  height: auto;
+  display: block;
+  object-fit: contain;
 }
 
 .hero__card-title {


### PR DESCRIPTION
## Summary
- replace the header wordmark with the newly supplied PNG logo and ensure it has a focus style
- swap the hero card illustration for the new icon and style it on a white tile to match the brand
- update the favicon link so the new icon is used in the browser tab

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e57efdea4083298cc4bb3b4344d621