### PR TITLE
Switch site theme to grayscale

### DIFF
--- a/images/mockup-placeholder.svg
+++ b/images/mockup-placeholder.svg
@@ -3,27 +3,27 @@
   <desc id="desc">Minimal illustration representing a Microsoft Power Platform workspace.</desc>
   <defs>
     <linearGradient id="placeholder-bg" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0%" stop-color="#E7F3EA" />
-      <stop offset="100%" stop-color="#BFDCC0" />
+      <stop offset="0%" stop-color="#f2f2f2" />
+      <stop offset="100%" stop-color="#d9d9d9" />
     </linearGradient>
   </defs>
   <rect width="720" height="540" rx="48" fill="url(#placeholder-bg)" />
   <g fill="#FFFFFF" opacity="0.92">
     <rect x="150" y="120" width="420" height="280" rx="28" />
   </g>
-  <g fill="#253140" opacity="0.18">
+  <g fill="#1f1f1f" opacity="0.18">
     <rect x="198" y="168" width="200" height="24" rx="12" />
     <rect x="198" y="204" width="140" height="18" rx="9" />
     <rect x="198" y="234" width="172" height="18" rx="9" />
   </g>
   <g opacity="0.75">
-    <rect x="198" y="276" width="324" height="72" rx="18" fill="#A9D9A7" />
+    <rect x="198" y="276" width="324" height="72" rx="18" fill="#cfcfcf" />
   </g>
-  <g opacity="0.22" fill="#253140">
+  <g opacity="0.22" fill="#1f1f1f">
     <rect x="342" y="168" width="132" height="24" rx="12" />
     <rect x="342" y="204" width="104" height="18" rx="9" />
     <rect x="342" y="234" width="116" height="18" rx="9" />
   </g>
   <rect x="240" y="312" width="240" height="60" rx="16" fill="#FFFFFF" opacity="0.85" />
-  <rect x="270" y="330" width="180" height="16" rx="8" fill="#253140" opacity="0.2" />
+  <rect x="270" y="330" width="180" height="16" rx="8" fill="#1f1f1f" opacity="0.2" />
 </svg>

--- a/styles/main.css
+++ b/styles/main.css
@@ -151,14 +151,14 @@ p {
 
 .button--ghost {
   background: transparent;
-  border: 1px solid rgba(37, 99, 235, 0.3);
+  border: 1px solid rgba(0, 0, 0, 0.3);
   color: var(--color-accent);
   box-shadow: none;
 }
 
 .button--ghost:hover,
 .button--ghost:focus-visible {
-  background: rgba(37, 99, 235, 0.08);
+  background: rgba(0, 0, 0, 0.08);
   box-shadow: none;
 }
 
@@ -169,7 +169,7 @@ p {
   z-index: 20;
   background: rgba(255, 255, 255, 0.92);
   backdrop-filter: blur(12px);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.3);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.1);
 }
 
 .site-header__inner {
@@ -249,7 +249,7 @@ p {
   justify-content: center;
   padding: 0.55rem;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(148, 163, 184, 0.4);
+  border: 1px solid rgba(0, 0, 0, 0.2);
   background: #fff;
   color: var(--color-text);
 }
@@ -297,8 +297,8 @@ p {
   position: absolute;
   inset: 8% 12% auto;
   height: clamp(280px, 50vw, 360px);
-  background: radial-gradient(circle at top left, rgba(37, 99, 235, 0.18), transparent 58%),
-    radial-gradient(circle at bottom right, rgba(16, 185, 129, 0.14), transparent 55%);
+  background: radial-gradient(circle at top left, rgba(0, 0, 0, 0.18), transparent 58%),
+    radial-gradient(circle at bottom right, rgba(0, 0, 0, 0.12), transparent 55%);
   filter: blur(0);
   border-radius: var(--radius-lg);
   z-index: 0;
@@ -345,7 +345,7 @@ p {
   background: rgba(255, 255, 255, 0.75);
   border-radius: var(--radius-sm);
   padding: 1rem 1.25rem;
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid rgba(0, 0, 0, 0.15);
   backdrop-filter: blur(6px);
 }
 
@@ -370,9 +370,9 @@ p {
   gap: 1.2rem;
   padding: clamp(2rem, 5vw, 2.5rem);
   border-radius: var(--radius-lg);
-  background: linear-gradient(160deg, var(--color-elevated), #1d4ed8);
-  color: #f8fafc;
-  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.32);
+  background: linear-gradient(160deg, var(--color-elevated), #444444);
+  color: #f5f5f5;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.32);
   max-width: 380px;
 }
 
@@ -381,7 +381,7 @@ p {
   height: 64px;
   border-radius: 18px;
   background: #fff;
-  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.18);
+  box-shadow: 0 18px 36px rgba(0, 0, 0, 0.18);
   display: grid;
   place-items: center;
 }
@@ -400,7 +400,7 @@ p {
 }
 
 .hero__card-copy {
-  color: rgba(226, 232, 240, 0.88);
+  color: rgba(255, 255, 255, 0.75);
 }
 
 .hero__metrics {
@@ -430,7 +430,7 @@ p {
   padding: 2rem;
   border-radius: var(--radius-sm);
   background: var(--color-surface);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  border: 1px solid rgba(0, 0, 0, 0.12);
   box-shadow: var(--shadow-xs);
   transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
@@ -476,7 +476,7 @@ p {
   width: 54px;
   height: 54px;
   border-radius: 16px;
-  background: rgba(37, 99, 235, 0.12);
+  background: rgba(0, 0, 0, 0.08);
   display: grid;
   place-items: center;
   color: var(--color-accent);
@@ -514,8 +514,8 @@ p {
   width: 1rem;
   height: 1rem;
   border-radius: 50%;
-  background: rgba(16, 185, 129, 0.18);
-  box-shadow: inset 0 0 0 2px rgba(16, 185, 129, 0.4);
+  background: rgba(0, 0, 0, 0.08);
+  box-shadow: inset 0 0 0 2px rgba(0, 0, 0, 0.25);
 }
 
 /* Contact */
@@ -528,8 +528,8 @@ p {
 .contact__details {
   padding: clamp(1.5rem, 4vw, 2rem);
   border-radius: var(--radius-sm);
-  background: rgba(219, 234, 254, 0.4);
-  border: 1px solid rgba(37, 99, 235, 0.25);
+  background: rgba(0, 0, 0, 0.05);
+  border: 1px solid rgba(0, 0, 0, 0.15);
 }
 
 .contact__list {
@@ -573,7 +573,7 @@ p {
   padding: clamp(1.75rem, 4vw, 2.25rem);
   border-radius: var(--radius-sm);
   background: var(--color-surface);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+  border: 1px solid rgba(0, 0, 0, 0.12);
   box-shadow: var(--shadow-xs);
   display: grid;
   gap: 1.25rem;
@@ -594,7 +594,7 @@ textarea {
   font: inherit;
   padding: 0.75rem 0.85rem;
   border-radius: var(--radius-sm);
-  border: 1px solid rgba(148, 163, 184, 0.6);
+  border: 1px solid rgba(0, 0, 0, 0.4);
   background: #fff;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
@@ -602,7 +602,7 @@ textarea {
 input:focus-visible,
 textarea:focus-visible {
   border-color: var(--color-accent);
-  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.18);
+  box-shadow: 0 0 0 3px rgba(0, 0, 0, 0.18);
   outline: none;
 }
 
@@ -615,7 +615,7 @@ textarea {
 .site-footer {
   margin-top: clamp(3rem, 6vw, 5rem);
   background: var(--color-elevated);
-  color: rgba(226, 232, 240, 0.92);
+  color: rgba(255, 255, 255, 0.9);
   padding-block: clamp(2.5rem, 5vw, 3.5rem);
 }
 
@@ -632,7 +632,7 @@ textarea {
 }
 
 .footer__tagline {
-  color: rgba(226, 232, 240, 0.75);
+  color: rgba(255, 255, 255, 0.7);
 }
 
 .footer-nav {
@@ -642,7 +642,7 @@ textarea {
 }
 
 .footer-nav a {
-  color: rgba(226, 232, 240, 0.85);
+  color: rgba(255, 255, 255, 0.85);
   font-weight: 500;
 }
 
@@ -674,14 +674,14 @@ textarea {
   width: 20px;
   height: 20px;
   fill: currentColor;
-  color: rgba(226, 232, 240, 0.9);
+  color: rgba(255, 255, 255, 0.9);
 }
 
 .footer__credit {
   margin: 2rem auto 0;
   text-align: center;
   font-size: 0.9rem;
-  color: rgba(226, 232, 240, 0.6);
+  color: rgba(255, 255, 255, 0.6);
 }
 
 /* Mobile navigation */
@@ -689,7 +689,7 @@ textarea {
   position: fixed;
   inset: 0;
   display: none;
-  background: rgba(15, 23, 42, 0.45);
+  background: rgba(0, 0, 0, 0.45);
   backdrop-filter: blur(6px);
   z-index: 60;
 }
@@ -706,7 +706,7 @@ textarea {
   padding: 2rem 1.75rem;
   display: grid;
   gap: 2rem;
-  box-shadow: -4px 0 24px rgba(15, 23, 42, 0.18);
+  box-shadow: -4px 0 24px rgba(0, 0, 0, 0.18);
 }
 
 .mobile-drawer__close {

--- a/styles/tokens.css
+++ b/styles/tokens.css
@@ -1,17 +1,17 @@
 :root {
-  --color-background: #f8fafc;
+  --color-background: #f5f5f5;
   --color-surface: #ffffff;
-  --color-elevated: #0f172a;
-  --color-text: #0f172a;
-  --color-muted: #475569;
-  --color-accent: #2563eb;
-  --color-accent-soft: #dbeafe;
-  --color-border: #d0d7de;
-  --color-success: #10b981;
+  --color-elevated: #111111;
+  --color-text: #111111;
+  --color-muted: #555555;
+  --color-accent: #000000;
+  --color-accent-soft: #e5e5e5;
+  --color-border: #d4d4d4;
+  --color-success: #222222;
   --radius-sm: 10px;
   --radius-lg: 20px;
-  --shadow-sm: 0 12px 40px rgba(15, 23, 42, 0.12);
-  --shadow-xs: 0 4px 20px rgba(15, 23, 42, 0.08);
+  --shadow-sm: 0 12px 40px rgba(0, 0, 0, 0.12);
+  --shadow-xs: 0 4px 20px rgba(0, 0, 0, 0.08);
   --max-width: 1120px;
   --section-space: clamp(3rem, 8vw, 6.5rem);
   --font-base: "Inter", "Segoe UI", "Helvetica Neue", Arial, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI Emoji", sans-serif;


### PR DESCRIPTION
## Summary
- update design tokens to a black and white inspired palette
- adapt component styles and overlays to use grayscale hues throughout the site
- refresh the mockup placeholder illustration to remove color accents

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5872746108329a2e7b8f303f2e5e6