### PR TITLE
Integrate Formspree for contact form and preserve native form POST behavior

### DIFF
--- a/CONTACT_FORM_SETUP.md
+++ b/CONTACT_FORM_SETUP.md
@@ -1,0 +1,30 @@
+# Contact form email setup
+
+This website is static HTML/CSS/JS, so the best integration is **Basic HTML form POST** to Formspree (no SDK or backend required).
+
+## Current configured endpoint
+
+The form is now configured to submit to:
+
+- `https://formspree.io/f/mbdpqnnr`
+
+in `partials/contact.html`.
+
+## How it works
+
+- Browser submits the form directly to Formspree with `method="POST"`.
+- Formspree forwards the message to your designated mailbox.
+- A hidden `_subject` field sets a useful email subject line.
+- A hidden `_gotcha` field acts as a lightweight spam trap.
+
+## If you ever need to change the destination form
+
+1. Create/open another form in Formspree.
+2. Copy its endpoint URL.
+3. Replace the `action` URL in `partials/contact.html`.
+4. Deploy and send a test submission.
+
+## Front-end behavior
+
+- `scripts/main.js` now keeps native form POST behavior (no AJAX interception).
+- On submit, it only handles client validation and shows a "Sending…" status while disabling the submit button.

--- a/partials/contact.html
+++ b/partials/contact.html
@@ -8,7 +8,13 @@
       </p>
     </header>
     <div class="section__content contact__content">
-      <form class="contact__form" action="#" method="post" novalidate>
+      <form
+        class="contact__form"
+        action="https://formspree.io/f/mbdpqnnr"
+        method="post"
+      >
+        <input type="hidden" name="_subject" value="New website contact form submission" />
+        <input type="text" name="_gotcha" tabindex="-1" autocomplete="off" aria-hidden="true" style="position:absolute;left:-5000px;" />
         <div class="form-field">
           <input id="contact-name" name="name" type="text" autocomplete="name" required placeholder=" " />
           <label for="contact-name">[Name label]</label>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -239,22 +239,27 @@ function setupContactForm(d) {
   const form = d.querySelector(SELECTORS.form);
   if (!form) return;
 
-  form.addEventListener('submit', (event) => {
-    event.preventDefault();
+  const status = form.querySelector('[data-form-status]');
+  const submitButton = form.querySelector('button[type="submit"]');
 
+  form.addEventListener('submit', (event) => {
     if (typeof form.checkValidity === 'function' && !form.checkValidity()) {
+      event.preventDefault();
       form.reportValidity?.();
       return;
     }
 
-    const status = form.querySelector('[data-form-status]');
     if (status) {
-      status.textContent = 'Thanks! We will get back to you within one business day.';
+      status.textContent = 'Sending…';
     }
 
-    form.reset();
+    if (submitButton) {
+      submitButton.disabled = true;
+      submitButton.setAttribute('aria-busy', 'true');
+    }
   });
 }
+
 
 function setupDarkModeToggle(d) {
   const toggle = d.getElementById('themeToggle');


### PR DESCRIPTION
### Motivation

- Provide a simple serverless email endpoint for the static site by wiring the contact form to Formspree.
- Restore native browser validation and allow the form to perform a normal POST instead of being intercepted by JavaScript.
- Improve user experience by showing a "Sending…" status and disabling the submit button while the browser posts, and add a lightweight spam trap and email subject.

### Description

- Added `CONTACT_FORM_SETUP.md` with the configured Formspree endpoint `https://formspree.io/f/mbdpqnnr` and setup/instruction notes. 
- Updated `partials/contact.html` to set the form `action` to the Formspree endpoint, removed `novalidate`, and added hidden inputs `_subject` and `_gotcha` for email subject and spam mitigation. 
- Modified `scripts/main.js` in `setupContactForm` to preserve native POST: perform client-side validity checks via `checkValidity()`/`reportValidity()` and only `preventDefault()` when invalid, set the status text to `Sending…`, and disable the submit button with `aria-busy` while the browser submits. 
- Removed the previous immediate `form.reset()` and other JS interception so submissions are forwarded directly to Formspree.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d40b595968832993f6e484488d9608)